### PR TITLE
fix(app): improve check for private/public routes

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "cy:run": "cypress run --headless",
     "deps:update": "updates -gu && pnpm -r exec updates -gu",
     "dev": "turbo run dev --parallel",
+    "dev:test": "turbo run dev --parallel -- --mode test",
     "lint": "run-s lint:check prettier:check",
     "lint:check": "eslint . --ext .ts,.tsx,.js,.jsx",
     "lint:fix": "pnpm lint:check --fix",
@@ -41,7 +42,7 @@
     "test:ci": "pnpm test -- --ci --testLocationInResults --json --coverage",
     "test:clear": "pnpm -r exec jest --clearCache",
     "test:coverage": "pnpm run --filter=app test --coverage",
-    "test:e2e": "run-p --race dev cy:run",
+    "test:e2e": "run-p --race dev:test cy:run",
     "ts:check": "pnpm -r ts:check",
     "prepare": "husky install"
   },

--- a/packages/app/cypress/e2e/CreateWallet.cy.ts
+++ b/packages/app/cypress/e2e/CreateWallet.cy.ts
@@ -19,7 +19,7 @@ describe('CreateWallet', () => {
     cy.get('button[role="checkbox"]').click();
     cy.contains('button', /Next/i).click();
 
-    /** COnfirm Mnemonic */
+    /** Confirm Mnemonic */
     cy.contains(/Write down your Recover Phrase/i);
     cy.contains('button', /Paste/i).click();
     cy.contains('button', /Next/i).click();
@@ -34,5 +34,12 @@ describe('CreateWallet', () => {
     /** Account created */
     cy.contains(/Wallet created succesfully/i);
     cy.contains(/Account 1/i);
+
+    /**
+     * Checking private and public routes
+     * Need reload() in order to see if will redirect to the right place
+     * */
+    cy.reload();
+    cy.visit('/wallet').contains(/assets/i);
   });
 });

--- a/packages/app/cypress/e2e/FaucetDialog.cy.ts
+++ b/packages/app/cypress/e2e/FaucetDialog.cy.ts
@@ -16,17 +16,9 @@ describe('FaucetDialog', () => {
     /** Ask to start Faucet */
     cy.contains('button', 'Give me ETH').click();
 
-    /** Checks loading */
-    cy.contains('button', /Loading/i);
-
-    /** Checks Done feedback */
-    cy.contains('button', 'Success. 0.5 ETH was added.');
-
     /** Checks if Balance in assets list refreshed */
     cy.contains('Ethereum');
     cy.contains('0,5 ETH');
-
-    /** Checks if Balance in BalanceWidget refreshed */
     cy.contains('ETH 0,5');
   });
 });

--- a/packages/app/cypress/e2e/FaucetDialog.cy.ts
+++ b/packages/app/cypress/e2e/FaucetDialog.cy.ts
@@ -19,6 +19,8 @@ describe('FaucetDialog', () => {
     /** Checks if Balance in assets list refreshed */
     cy.contains('Ethereum');
     cy.contains('0,5 ETH');
+
+    /** Checks if Balance in BalanceWidget refreshed */
     cy.contains('ETH 0,5');
   });
 });

--- a/packages/app/cypress/utils/test-utils.ts
+++ b/packages/app/cypress/utils/test-utils.ts
@@ -1,13 +1,16 @@
 import { Wallet } from 'fuels';
 
+import { IS_LOGGED_KEY } from '~/config';
 import type { Account } from '~/systems/Account';
 
 export const clearMocks = () => {
+  localStorage.removeItem(IS_LOGGED_KEY);
   cy.clearIndexedDb('FuelDB');
 };
 
 export const mockAccount = (account?: Account) => {
   // needs to set version 8 to openIndexedDb, to match version 10 of application.
+  localStorage.setItem(IS_LOGGED_KEY, 'true');
   cy.openIndexedDb('FuelDB', 8).as('db');
 
   const wallet = Wallet.generate();

--- a/packages/app/cypress/utils/test-utils.ts
+++ b/packages/app/cypress/utils/test-utils.ts
@@ -18,7 +18,6 @@ export const mockAccount = (account?: Account) => {
   };
 
   cy.getIndexedDb('@db').createObjectStore('accounts').createItem(accountData.address, accountData);
-
   cy.getIndexedDb('@db').createObjectStore('vaults');
 
   return accountData;

--- a/packages/app/cypress/utils/test-utils.ts
+++ b/packages/app/cypress/utils/test-utils.ts
@@ -4,12 +4,10 @@ import type { Account } from '~/systems/Account';
 
 export const clearMocks = () => {
   cy.clearIndexedDb('FuelDB');
-  localStorage.removeItem('fuel__isLogged');
 };
 
 export const mockAccount = (account?: Account) => {
   // needs to set version 8 to openIndexedDb, to match version 10 of application.
-  localStorage.setItem('fuel__isLogged', 'true');
   cy.openIndexedDb('FuelDB', 8).as('db');
 
   const wallet = Wallet.generate();

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -6,3 +6,5 @@ export const FORMAT_LANGUAGE = 'es';
 export const MIN_FRACTION_DIGITS = 1;
 export const MAX_FRACTION_DIGITS = 3;
 export const MNEMONIC_SIZE = 16;
+
+export const IS_LOGGED_KEY = 'fuel__isLogged';

--- a/packages/app/src/systems/Account/events.tsx
+++ b/packages/app/src/systems/Account/events.tsx
@@ -1,11 +1,7 @@
 import { createEvent } from "@fuels-wallet/mediator";
 
-import type { Account } from "./types";
-
 enum Events {
-  accountCreated = "accounts:ACCOUNT_CREATED",
-  faucetSuccess = "accounts:FAUCET_SUCCESS",
+  updateAccounts = "accounts:UPDATE_ACCOUNTS",
 }
 
-export const accountCreated = createEvent<Account>(Events.accountCreated);
-export const faucetSuccess = createEvent<void>(Events.faucetSuccess);
+export const updateAccounts = createEvent(Events.updateAccounts);

--- a/packages/app/src/systems/Account/hooks/index.tsx
+++ b/packages/app/src/systems/Account/hooks/index.tsx
@@ -1,1 +1,2 @@
 export * from "./useAccounts";
+export * from "./useIsLogged";

--- a/packages/app/src/systems/Account/hooks/useAccounts.tsx
+++ b/packages/app/src/systems/Account/hooks/useAccounts.tsx
@@ -8,10 +8,10 @@ import { useGlobalMachines } from "~/systems/Core";
 const selectors = {
   isLoading: (state: AccountsMachineState) => state?.hasTag("loading"),
   account: (state: AccountsMachineState) => {
-    return state.context.account;
+    return state?.context.account;
   },
   accounts: (state: AccountsMachineState) => {
-    return AccountService.fromMap(state.context.accounts || {});
+    return AccountService.fromMap(state?.context.accounts || {});
   },
 };
 

--- a/packages/app/src/systems/Account/hooks/useIsLogged.tsx
+++ b/packages/app/src/systems/Account/hooks/useIsLogged.tsx
@@ -1,0 +1,5 @@
+import { IS_LOGGED_KEY } from "~/config";
+
+export function useIsLogged() {
+  return localStorage.getItem(IS_LOGGED_KEY);
+}

--- a/packages/app/src/systems/Account/machines/accountsMachine.tsx
+++ b/packages/app/src/systems/Account/machines/accountsMachine.tsx
@@ -5,6 +5,8 @@ import { assign, createMachine } from "xstate";
 import { accountEvents, AccountService } from "..";
 import type { Account } from "../types";
 
+import { IS_LOGGED_KEY } from "~/config";
+
 type MachineContext = {
   accounts?: Record<string, Account>;
   account?: Account;
@@ -43,11 +45,12 @@ export const accountsMachine = createMachine(
           src: "fetchAccounts",
           onDone: [
             {
-              actions: ["assignAccounts"],
+              actions: ["assignAccounts", "setLocalStorage"],
               target: "fetchingBalances",
               cond: "hasAccount",
             },
             {
+              actions: ["removeLocalStorage"],
               target: "done",
             },
           ],
@@ -108,6 +111,12 @@ export const accountsMachine = createMachine(
       assignError: assign({
         error: (_, ev) => ev.data,
       }),
+      setLocalStorage: () => {
+        localStorage.setItem(IS_LOGGED_KEY, "true");
+      },
+      removeLocalStorage: () => {
+        localStorage.removeItem(IS_LOGGED_KEY);
+      },
     },
     services: {
       async fetchAccounts() {

--- a/packages/app/src/systems/Core/components/PrivateRoute/PrivateRoute.tsx
+++ b/packages/app/src/systems/Core/components/PrivateRoute/PrivateRoute.tsx
@@ -1,21 +1,16 @@
-import { Spinner } from "@fuel-ui/react";
 import type { ReactNode } from "react";
 import { Navigate } from "react-router-dom";
 
-import { useAccounts } from "~/systems/Account";
+import { useIsLogged } from "~/systems/Account";
 
 type PrivateRouteProps = {
   children: ReactNode;
 };
 
 export function PrivateRoute({ children }: PrivateRouteProps) {
-  const { account, isLoading } = useAccounts();
+  const isLogged = useIsLogged();
 
-  if (import.meta.env.MODE === "test" && isLoading) {
-    return <Spinner />;
-  }
-
-  if (!account) {
+  if (!isLogged) {
     return <Navigate to="/sign-up" replace />;
   }
 

--- a/packages/app/src/systems/Core/components/PrivateRoute/PrivateRoute.tsx
+++ b/packages/app/src/systems/Core/components/PrivateRoute/PrivateRoute.tsx
@@ -8,9 +8,9 @@ type PrivateRouteProps = {
 };
 
 export function PrivateRoute({ children }: PrivateRouteProps) {
-  const { accounts } = useAccounts();
+  const { account } = useAccounts();
 
-  if (accounts != null && !accounts?.length) {
+  if (!account) {
     return <Navigate to="/sign-up" replace />;
   }
 

--- a/packages/app/src/systems/Core/components/PrivateRoute/PrivateRoute.tsx
+++ b/packages/app/src/systems/Core/components/PrivateRoute/PrivateRoute.tsx
@@ -1,3 +1,4 @@
+import { Spinner } from "@fuel-ui/react";
 import type { ReactNode } from "react";
 import { Navigate } from "react-router-dom";
 
@@ -8,7 +9,11 @@ type PrivateRouteProps = {
 };
 
 export function PrivateRoute({ children }: PrivateRouteProps) {
-  const { account } = useAccounts();
+  const { account, isLoading } = useAccounts();
+
+  if (import.meta.env.MODE === "test" && isLoading) {
+    return <Spinner />;
+  }
 
   if (!account) {
     return <Navigate to="/sign-up" replace />;

--- a/packages/app/src/systems/Core/components/PublicRoute/PublicRoute.tsx
+++ b/packages/app/src/systems/Core/components/PublicRoute/PublicRoute.tsx
@@ -1,19 +1,19 @@
 import type { ReactNode } from "react";
 import { Navigate, useLocation, useResolvedPath } from "react-router-dom";
 
-import { useAccounts } from "~/systems/Account";
+import { useIsLogged } from "~/systems/Account";
 
 type PublicRouteProps = {
   children: ReactNode;
 };
 
 export function PublicRoute({ children }: PublicRouteProps) {
-  const { account } = useAccounts();
   const location = useLocation();
   const match = useResolvedPath(location.pathname);
+  const isLogged = useIsLogged();
   const isSignUp = match.pathname.includes("/sign-up");
 
-  if (!isSignUp && !account) {
+  if (isSignUp && isLogged) {
     return <Navigate to="/wallet" replace />;
   }
 

--- a/packages/app/src/systems/Core/components/PublicRoute/PublicRoute.tsx
+++ b/packages/app/src/systems/Core/components/PublicRoute/PublicRoute.tsx
@@ -8,17 +8,12 @@ type PublicRouteProps = {
 };
 
 export function PublicRoute({ children }: PublicRouteProps) {
-  const { accounts } = useAccounts();
+  const { account } = useAccounts();
   const location = useLocation();
   const match = useResolvedPath(location.pathname);
   const isSignUp = match.pathname.includes("/sign-up");
-  const isLogged = localStorage.getItem("fuel__isLogged");
 
-  if (isLogged) {
-    return <Navigate to="/wallet" replace />;
-  }
-
-  if (!isSignUp && accounts != null && accounts?.length) {
+  if (!isSignUp && !account) {
     return <Navigate to="/wallet" replace />;
   }
 

--- a/packages/app/src/systems/Faucet/machines/faucetMachine.tsx
+++ b/packages/app/src/systems/Faucet/machines/faucetMachine.tsx
@@ -90,7 +90,7 @@ export const faucetMachine =
         assignAddress: assign({ address: (_, ev) => ev.data.address }),
         assignCaptcha: assign({ captcha: (_, ev) => ev.data.captcha }),
         assignError: assign({ error: (_, ev) => ev.data }),
-        sendFaucetSuccess: () => accountEvents.faucetSuccess(),
+        sendFaucetSuccess: () => accountEvents.updateAccounts(),
         navigateToHome: () => {},
         showDoneFeedback: () => {
           toast.success("Success, 0.5 ETH was added to your wallet.");

--- a/packages/app/src/systems/SignUp/components/WalletCreated/WalletCreated.tsx
+++ b/packages/app/src/systems/SignUp/components/WalletCreated/WalletCreated.tsx
@@ -1,5 +1,4 @@
 import { Stack, Button, Flex } from "@fuel-ui/react";
-import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 
 import { Header } from "../Header";
@@ -19,10 +18,6 @@ export function WalletCreated({ account }: WalletCreatedProps) {
   function handleGoToWallet() {
     navigate("/wallet");
   }
-
-  useEffect(() => {
-    localStorage.setItem("fuel__isLogged", "true");
-  }, []);
 
   return (
     <Stack gap="$6">

--- a/packages/app/src/systems/SignUp/machines/signUpMachine.ts
+++ b/packages/app/src/systems/SignUp/machines/signUpMachine.ts
@@ -3,7 +3,7 @@ import { Mnemonic } from '@fuel-ts/mnemonic';
 import type { InterpreterFrom, StateFrom } from 'xstate';
 import { assign, createMachine } from 'xstate';
 
-import { MNEMONIC_SIZE } from '~/config';
+import { IS_LOGGED_KEY, MNEMONIC_SIZE } from '~/config';
 import type { Account } from '~/systems/Account';
 import { AccountService, accountEvents } from '~/systems/Account';
 import { getPhraseFromValue, getWordsFromValue } from '~/systems/Core';
@@ -165,6 +165,7 @@ export const signUpMachine = createMachine(
         data: (_) => null,
       }),
       sendAccountCreated: () => {
+        localStorage.setItem(IS_LOGGED_KEY, 'true');
         accountEvents.updateAccounts();
       },
     },

--- a/packages/app/src/systems/SignUp/machines/signUpMachine.ts
+++ b/packages/app/src/systems/SignUp/machines/signUpMachine.ts
@@ -164,10 +164,8 @@ export const signUpMachine = createMachine(
       deleteData: assign({
         data: (_) => null,
       }),
-      sendAccountCreated: (ctx) => {
-        if (ctx.account) {
-          accountEvents.accountCreated(ctx.account);
-        }
+      sendAccountCreated: () => {
+        accountEvents.updateAccounts();
       },
     },
     guards: {

--- a/packages/mediator/src/mediator.ts
+++ b/packages/mediator/src/mediator.ts
@@ -14,14 +14,16 @@ if (service.status !== InterpreterStatus.Running) {
   service.start();
 }
 
+type ArrayType<T> = T extends (infer Item)[] ? Item[] : T;
+
 /**
  * This function will create an event that will be used to send/register
  * inside the mediator
  */
-export function createEvent<T = any>(name: string) {
-  const fn = (data: T) => {
-    service.send('send', { name, data });
-  };
+export function createEvent(name: string) {
+  function fn<T extends ArrayType<any>>(...args: T extends any[] ? T : never) {
+    service.send('send', { name, data: args[0] });
+  }
   fn._name = name;
   return fn;
 }


### PR DESCRIPTION
> **Note**
>We still need localStorage to avoid users being redirected to /sign-up when reloading the page. Another way of doing this without needing the localStorage is by having a `<Spinner>` every time on `<PrivateRoute>`, but I think this is better to avoid spinners