### PR TITLE
feat(fetchMachine): add `maxAttempts`

### DIFF
--- a/packages/app/src/systems/Core/machines/fetchMachine.test.ts
+++ b/packages/app/src/systems/Core/machines/fetchMachine.test.ts
@@ -1,0 +1,90 @@
+import { toast } from '@fuel-ui/react';
+import { interpret } from 'xstate';
+import { waitFor } from 'xstate/lib/waitFor';
+
+import type { CreateFetchMachineOpts } from './fetchMachine';
+import { FetchMachine } from './fetchMachine';
+
+const fetchForceSuccess = () => Promise.resolve('string');
+const fetchForceError = async () => {
+  throw new Error('force error');
+};
+
+const errorToastSpy = jest.spyOn(toast, 'error');
+
+describe('fetchMachine', () => {
+  const createService = (opts: CreateFetchMachineOpts<string, string>) => {
+    jest.spyOn(console, 'error').mockImplementation();
+    const fetchService = { fetch: opts.fetch };
+    const fetchSpy = jest.spyOn(fetchService, 'fetch');
+    const machine = FetchMachine.create({
+      showError: true,
+      maxAttempts: 3,
+      ...opts,
+      fetch: fetchService.fetch,
+    });
+    const service = interpret(machine.withContext({})).start();
+
+    return { fetchSpy, service };
+  };
+
+  afterEach(() => {
+    errorToastSpy.mockClear();
+  });
+
+  it('should fail after attempting 1 time', async () => {
+    const { fetchSpy, service } = createService({
+      maxAttempts: 1,
+      fetch: fetchForceError,
+    });
+    await waitFor(service, (state) => state.matches('failed'));
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should fail after attempting 3 times', async () => {
+    const { fetchSpy, service } = createService({
+      maxAttempts: 3,
+      fetch: fetchForceError,
+    });
+    await waitFor(service, (state) => state.matches('failed'));
+    expect(fetchSpy).toHaveBeenCalledTimes(3);
+  });
+
+  it('should fail after attempting 5 times', async () => {
+    const { fetchSpy, service } = createService({
+      maxAttempts: 5,
+      fetch: fetchForceError,
+    });
+    await waitFor(service, (state) => state.matches('failed'));
+    expect(fetchSpy).toHaveBeenCalledTimes(5);
+  });
+
+  it('should show error when failing and showError: true', async () => {
+    const errorToastSpy = jest.spyOn(toast, 'error');
+    const { service } = createService({
+      maxAttempts: 1,
+      fetch: fetchForceError,
+    });
+    await waitFor(service, (state) => state.matches('failed'));
+    expect(errorToastSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should NOT show error when failing and showError: false', async () => {
+    const { service } = createService({
+      showError: false,
+      maxAttempts: 1,
+      fetch: fetchForceError,
+    });
+    await waitFor(service, (state) => state.matches('failed'));
+    expect(errorToastSpy).toHaveBeenCalledTimes(0);
+  });
+
+  it('should work straight when has no errorNOT show error when failing and showError: false', async () => {
+    const { fetchSpy, service } = createService({
+      fetch: fetchForceSuccess,
+    });
+    await waitFor(service, (state) => state.matches('success'));
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(errorToastSpy).toHaveBeenCalledTimes(0);
+  });
+});

--- a/packages/app/src/systems/Core/machines/fetchMachine.test.ts
+++ b/packages/app/src/systems/Core/machines/fetchMachine.test.ts
@@ -15,13 +15,13 @@ const errorToastSpy = jest.spyOn(toast, 'error');
 describe('fetchMachine', () => {
   const createService = (opts: CreateFetchMachineOpts<string, string>) => {
     jest.spyOn(console, 'error').mockImplementation();
-    const fetchService = { fetch: opts.fetch };
-    const fetchSpy = jest.spyOn(fetchService, 'fetch');
+    const fetchWrapper = { fetch: opts.fetch };
+    const fetchSpy = jest.spyOn(fetchWrapper, 'fetch');
     const machine = FetchMachine.create({
       showError: true,
       maxAttempts: 3,
       ...opts,
-      fetch: fetchService.fetch,
+      fetch: fetchWrapper.fetch,
     });
     const service = interpret(machine.withContext({})).start();
 

--- a/packages/app/src/systems/Core/machines/fetchMachine.ts
+++ b/packages/app/src/systems/Core/machines/fetchMachine.ts
@@ -18,10 +18,13 @@ type MachineServices<R> = {
   };
 };
 
-type CreateFetchMachineOpts<I, R> = {
+export type CreateFetchMachineOpts<I, R> = {
   showError?: boolean;
+  maxAttempts?: number;
   fetch: (ctx: MachineContext<I>) => Promise<R>;
 };
+
+const MAX_ATTEMPTS = 3;
 
 export const FetchMachine = {
   hasError(_: any, ev: { data: { error?: any } }) {
@@ -46,6 +49,7 @@ export const FetchMachine = {
         states: {
           loading: {
             tags: ['loading'],
+            entry: ['incrementAttemps'],
             invoke: {
               src: 'fetch',
               onDone: {
@@ -58,6 +62,7 @@ export const FetchMachine = {
                   cond: 'hasManyAttempts',
                 },
                 {
+                  actions: ['logError'],
                   target: 'retrying',
                 },
               ],
@@ -65,7 +70,6 @@ export const FetchMachine = {
           },
           retrying: {
             tags: ['loading'],
-            entry: ['logError', 'incrementAttemps'],
             after: {
               500: {
                 target: 'loading',
@@ -103,7 +107,9 @@ export const FetchMachine = {
         },
         guards: {
           hasManyAttempts: (ctx) => {
-            return Boolean((ctx?.attempts ?? 0) > 3);
+            return Boolean(
+              (ctx?.attempts ?? 0) >= (opts?.maxAttempts || MAX_ATTEMPTS)
+            );
           },
         },
         services: {


### PR DESCRIPTION
- add `maxAttempts` option to fetchMachine, allowing it to be inputted instead of always being 3.
- fix retries running more times than expected
- add tests to the often used `fetchMachine.tsx`

Closes #149 
Closes #150 
Closes #151 