### PR TITLE
feat: add fuelweb on deps

### DIFF
--- a/packages/docs/src/hooks/useLoading.tsx
+++ b/packages/docs/src/hooks/useLoading.tsx
@@ -5,6 +5,7 @@ export function useLoading<T extends (...args: any) => Promise<void>>(
   callback: T,
   deps: any = []
 ) {
+  const [FuelWeb3] = useFuelWeb3();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>();
   const execute = useCallback(
@@ -19,7 +20,7 @@ export function useLoading<T extends (...args: any) => Promise<void>>(
           setLoading(false);
         });
     },
-    [...deps]
+    [FuelWeb3, ...deps]
   );
 
   return [execute as T, loading, error] as const;

--- a/packages/docs/src/hooks/useLoading.tsx
+++ b/packages/docs/src/hooks/useLoading.tsx
@@ -1,6 +1,8 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { useState, useCallback } from 'react';
 
+import { useFuelWeb3 } from './useFuelWeb3';
+
 export function useLoading<T extends (...args: any) => Promise<void>>(
   callback: T,
   deps: any = []


### PR DESCRIPTION
When FuelWeb3 was loaded all places that useLoading were not receiving the new FuelWeb3 reference.