### PR TITLE
fix(app): creation of services obj on store

### DIFF
--- a/packages/app/src/store.tsx
+++ b/packages/app/src/store.tsx
@@ -3,24 +3,19 @@ import { createStore } from '@fuel-wallet/xstore';
 import { accountEvents } from './systems/Account/events';
 import { networkEvents } from './systems/Network/events';
 
-import type { AccountMachine } from '~/systems/Account';
-import { accountMachine } from '~/systems/Account';
-import type { NetworksMachine } from '~/systems/Network';
-import { networksMachine } from '~/systems/Network';
+import { accountMachine } from '~/systems/Account/machines';
+import { networksMachine } from '~/systems/Network/machines';
 
 export enum Services {
   account = 'account',
   networks = 'networks',
 }
 
-export type StoreMachines = {
-  account: AccountMachine;
-  networks: NetworksMachine;
-};
+export type StoreMachines = typeof services;
 
 const services = {
-  account: accountMachine,
-  networks: networksMachine,
+  account: () => accountMachine,
+  networks: () => networksMachine,
 };
 
 export const store = createStore(services, {

--- a/packages/app/src/systems/Account/machines/accountMachine.tsx
+++ b/packages/app/src/systems/Account/machines/accountMachine.tsx
@@ -122,9 +122,7 @@ export const accountMachine = createMachine(
           const providerUrl = selectedNetwork?.url || defaultProvider;
           const accounts = await AccountService.getAccounts();
           const account = accounts[0];
-          if (!account) {
-            return undefined;
-          }
+          if (!account) return undefined;
           return AccountService.fetchBalance({ account, providerUrl });
         },
       }),

--- a/packages/app/src/systems/Home/pages/Home/Home.stories.tsx
+++ b/packages/app/src/systems/Home/pages/Home/Home.stories.tsx
@@ -3,6 +3,7 @@ import { graphql } from 'msw';
 
 import { Home } from './Home';
 
+import { store } from '~/store';
 import { AccountService, MOCK_ACCOUNTS } from '~/systems/Account';
 import { MOCK_ASSETS_NODE } from '~/systems/Asset/__mocks__/assets';
 
@@ -19,6 +20,7 @@ export default {
     async () => {
       await AccountService.clearAccounts();
       await AccountService.addAccount({ data: MOCK_ACCOUNTS[0] });
+      store.reset();
       return {};
     },
   ],
@@ -38,6 +40,7 @@ NoAssets.parameters = {
     }),
   ],
 };
+
 export const WithAssets: StoryFn<unknown> = () => <Home />;
 WithAssets.parameters = {
   msw: [

--- a/packages/store/src/types.ts
+++ b/packages/store/src/types.ts
@@ -19,31 +19,31 @@ export type Events = {
   [K in string]: (...args: any[]) => any;
 };
 
-export type MachinesObj = Record<string, AnyStateMachine>;
+export type MachinesObj = Record<string, () => AnyStateMachine>;
 export type ServicesObj = Record<string, AnyInterpreter>;
 export type StateObj<T extends MachinesObj> = Record<
   keyof T,
   StateFrom<
     StateMachine<
-      ValueOf<T>['__TContext'],
-      ValueOf<T>['__TStateSchema'],
-      ValueOf<T>['__TEvent'],
-      ValueOf<T>['__TTypestate'],
-      ValueOf<T>['__TAction'],
-      ValueOf<T>['__TServiceMap'],
-      ValueOf<T>['__TResolvedTypesMeta']
+      ReturnType<ValueOf<T>>['__TContext'],
+      ReturnType<ValueOf<T>>['__TStateSchema'],
+      ReturnType<ValueOf<T>>['__TEvent'],
+      ReturnType<ValueOf<T>>['__TTypestate'],
+      ReturnType<ValueOf<T>>['__TAction'],
+      ReturnType<ValueOf<T>>['__TServiceMap'],
+      ReturnType<ValueOf<T>>['__TResolvedTypesMeta']
     >
   >
 >;
 export type Service<T extends MachinesObj> = InterpreterFrom<
   StateMachine<
-    ValueOf<T>['__TContext'],
-    ValueOf<T>['__TStateSchema'],
-    ValueOf<T>['__TEvent'],
-    ValueOf<T>['__TTypestate'],
-    ValueOf<T>['__TAction'],
-    ValueOf<T>['__TServiceMap'],
-    ValueOf<T>['__TResolvedTypesMeta']
+    ReturnType<ValueOf<T>>['__TContext'],
+    ReturnType<ValueOf<T>>['__TStateSchema'],
+    ReturnType<ValueOf<T>>['__TEvent'],
+    ReturnType<ValueOf<T>>['__TTypestate'],
+    ReturnType<ValueOf<T>>['__TAction'],
+    ReturnType<ValueOf<T>>['__TServiceMap'],
+    ReturnType<ValueOf<T>>['__TResolvedTypesMeta']
   >
 > & {
   __storeKey: keyof T;


### PR DESCRIPTION
## Tasks

- [x] Fix dependency cycle when setting services object for store creation by adding a callback that will be called in the `StoreClass` constructor instead of getting the machine itself directly. This will avoid `undefined` at startup/compile time.

```jsx
// before
const services = {
  account: accountMachine
}

// after
const services = {
  account: () => accountMachine
}
```

- [x] In some storybook stories after changing between stories and setting some mocks using `MSW`, since the store is a global object, the mock data wasn't being applied. Now the store has a `reset()` method that can be added in `.stories` loaders to reset the global store state. This will fix `MSW` mocks for stories.