### PR TITLE
feat: create TransactionType enum and TxIcon component

### DIFF
--- a/packages/app/src/systems/Transaction/components/TxIcon/TxIcon.stories.tsx
+++ b/packages/app/src/systems/Transaction/components/TxIcon/TxIcon.stories.tsx
@@ -1,0 +1,24 @@
+import { TransactionType } from '@fuel-wallet/types';
+
+import type { TxIconProps } from './TxIcon';
+import { TxIcon } from './TxIcon';
+
+export default {
+  component: TxIcon,
+  title: 'Transaction/Components/TxIcon',
+  argTypes: {
+    type: {
+      options: Object.values(TransactionType).filter(
+        (type) => typeof type !== 'string'
+      ),
+      control: {
+        type: 'radio',
+        labels: Object.values(TransactionType).filter(
+          (type) => typeof type === 'string'
+        ),
+      },
+    },
+  },
+};
+
+export const Default = (args: TxIconProps) => <TxIcon {...args} />;

--- a/packages/app/src/systems/Transaction/components/TxIcon/TxIcon.test.tsx
+++ b/packages/app/src/systems/Transaction/components/TxIcon/TxIcon.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen, testA11y } from '@fuel-ui/test-utils';
+import { TransactionType } from '@fuel-wallet/types';
+
+import { TxIcon } from './TxIcon';
+
+describe('TxIcon', () => {
+  it('a11y', async () => {
+    await testA11y(<TxIcon type={TransactionType.Receive} />);
+  });
+
+  it('should render icon correctly', async () => {
+    await render(<TxIcon type={TransactionType.Receive} />);
+    expect(screen.getByText('DownloadSimple')).toBeInTheDocument();
+    await render(<TxIcon type={TransactionType.ContractCall} />);
+    expect(screen.getByText('ArrowsLeftRight')).toBeInTheDocument();
+    await render(<TxIcon type={TransactionType.Script} />);
+    expect(screen.getByText('MagicWand')).toBeInTheDocument();
+  });
+
+  it('should render loading state correctly', async () => {
+    await render(<TxIcon type={TransactionType.ContractCall} isLoading />);
+    expect(() => screen.getByText('ArrowsLeftRight')).toThrow();
+    await render(<TxIcon type={TransactionType.ContractCall} />);
+    expect(screen.getByText('ArrowsLeftRight')).toBeInTheDocument();
+  });
+});

--- a/packages/app/src/systems/Transaction/components/TxIcon/TxIcon.tsx
+++ b/packages/app/src/systems/Transaction/components/TxIcon/TxIcon.tsx
@@ -1,0 +1,48 @@
+import { cssObj } from '@fuel-ui/css';
+import { Flex, Icon } from '@fuel-ui/react';
+import { TransactionType } from '@fuel-wallet/types';
+
+const getIcon = (type: TransactionType) => {
+  switch (type) {
+    case TransactionType.Send:
+      return Icon.is('UploadSimple');
+    case TransactionType.Receive:
+      return Icon.is('DownloadSimple');
+    case TransactionType.ContractCall:
+      return Icon.is('ArrowsLeftRight');
+    case TransactionType.Script:
+      return Icon.is('MagicWand');
+    case TransactionType.Predicate:
+      return Icon.is('MagicWand');
+    default:
+      return 'ArrowRight';
+  }
+};
+
+export type TxIconProps = {
+  type: TransactionType;
+  isLoading?: boolean;
+};
+
+export function TxIcon({ type, isLoading }: TxIconProps) {
+  return (
+    <Flex css={styles.root({ isLoading })}>
+      {!isLoading ? <Icon icon={getIcon(type)} /> : null}
+    </Flex>
+  );
+}
+
+const styles = {
+  root: ({ isLoading }: { isLoading?: boolean }) =>
+    cssObj({
+      alignItems: 'center',
+      justifyContent: 'center',
+      display: 'flex',
+      ...(!isLoading && { backgroundColor: '$gray4' }),
+      ...(isLoading && { backgroundColor: '$gray6' }),
+      padding: '$2',
+      height: '$6',
+      width: '$6',
+      borderRadius: '$full',
+    }),
+};

--- a/packages/app/src/systems/Transaction/components/TxIcon/index.tsx
+++ b/packages/app/src/systems/Transaction/components/TxIcon/index.tsx
@@ -1,0 +1,1 @@
+export * from './TxIcon';

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -5,3 +5,4 @@ export * from './network';
 export * from './connection';
 export * from './fuelweb3';
 export * from './constants';
+export * from './transaction';

--- a/packages/types/src/transaction.ts
+++ b/packages/types/src/transaction.ts
@@ -1,0 +1,7 @@
+export enum TransactionType {
+  Send,
+  Receive,
+  ContractCall,
+  Script,
+  Predicate,
+}


### PR DESCRIPTION
This PR creaetes the TransactionType enum for the TxItem, and the TxIcon components.

Closes #33 

https://www.loom.com/share/e5785de8b7d24fbcaf65be565193d439