### PR TITLE
chore: remove storybook on docs production

### DIFF
--- a/packages/docs/src/components/Header.tsx
+++ b/packages/docs/src/components/Header.tsx
@@ -28,13 +28,15 @@ export function Header() {
           <Link href="/docs/install" className={isDocsActive ? 'active' : ''}>
             Docs
           </Link>
-          <a
-            href={process.env.NEXT_PUBLIC_STORYBOOK_URL}
-            target="_blank"
-            rel="noreferrer"
-          >
-            Storybook
-          </a>
+          {process.env.NEXT_PUBLIC_PREVIEW && (
+            <a
+              href={process.env.NEXT_PUBLIC_STORYBOOK_URL}
+              target="_blank"
+              rel="noreferrer"
+            >
+              Storybook
+            </a>
+          )}
           <a
             href="https://github.com/fuellabs/fuels-wallet"
             target="_blank"


### PR DESCRIPTION
The main focus of the live docs is just the wallet usage and installation. The storybook is not related to it. Because of this, we should hide it on the main website.