### PR TITLE
fix: close window after tx is sent

### DIFF
--- a/packages/app/playwright/e2e/ChangePassword.test.ts
+++ b/packages/app/playwright/e2e/ChangePassword.test.ts
@@ -28,6 +28,7 @@ test.describe('ChangePassword', () => {
     await getByAriaLabel(page, 'Confirm Password').type('newPass12345');
 
     // submit data
+    await hasText(page, 'Save');
     await getButtonByText(page, 'Save').click();
     await hasText(page, /assets/i, 1);
   });

--- a/packages/app/src/systems/DApp/methods/transactionRequestMethods.ts
+++ b/packages/app/src/systems/DApp/methods/transactionRequestMethods.ts
@@ -34,7 +34,7 @@ export class TransactionRequestMethods extends ExtensionPageConnection {
     const transactionRequest = transactionRequestify(JSON.parse(transaction));
     const input = { origin, transactionRequest, providerUrl };
     this.service.send('START_REQUEST', { input });
-    const state = await waitForState(this.service, 'idle' || 'done');
+    const state = await waitForState(this.service, 'txSuccess');
     return state.response?.approvedTx?.id;
   }
 }


### PR DESCRIPTION
After tx was complete, the DApp was not receiving the event and closing as expected.