### PR TITLE
feat: add logout action

### DIFF
--- a/packages/app/playwright/e2e/Logout.test.ts
+++ b/packages/app/playwright/e2e/Logout.test.ts
@@ -1,0 +1,28 @@
+import type { Browser, Page } from '@playwright/test';
+import test, { chromium } from '@playwright/test';
+
+import { getButtonByText, hasText, reload, visit } from '../commons';
+import { mockData } from '../mocks';
+
+test.describe('Logout', () => {
+  let browser: Browser;
+  let page: Page;
+
+  test.beforeAll(async () => {
+    browser = await chromium.launch();
+    page = await browser.newPage();
+  });
+
+  test.beforeEach(async () => {
+    await visit(page, '/');
+    await mockData(page, 2);
+    await reload(page);
+  });
+
+  test('Should logout and redirect to create new wallet', async () => {
+    await visit(page, '/accounts/logout');
+    await hasText(page, 'Logout');
+    await getButtonByText(page, 'Logout').click();
+    await hasText(page, 'Create a new Fuel Wallet');
+  });
+});

--- a/packages/app/playwright/e2e/SelectWallet.test.ts
+++ b/packages/app/playwright/e2e/SelectWallet.test.ts
@@ -30,11 +30,13 @@ test.describe('SelectWallet', () => {
 
   test('should be able to switch between accounts', async () => {
     await visit(page, '/wallet');
+    await hasText(page, /Assets/i);
     await getByAriaLabel(page, 'Accounts').click();
     await hasText(page, data.accounts[0].name);
     await hasText(page, data.accounts[1].name);
     await getByAriaLabel(page, data.accounts[1].name).click();
     await waitUrl(page, '/wallet');
+    await hasText(page, /Assets/i);
     const address = data.accounts[1].address.toString();
     await hasAriaLabel(page, address);
   });

--- a/packages/app/src/mocks/localStorage.ts
+++ b/packages/app/src/mocks/localStorage.ts
@@ -1,20 +1,23 @@
 class LocalStorageMock {
-  store = new Map();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [key: string]: any;
 
   clear() {
-    this.store.clear();
+    Object.keys(this).forEach((key) => {
+      delete this[key];
+    });
   }
 
   getItem(key: string) {
-    return this.store.get(key);
+    return this[key] || null;
   }
 
   setItem(key: string, value: string) {
-    this.store.set(key, value.toString());
+    this[key] = value.toString();
   }
 
   removeItem(key: string) {
-    this.store.delete(key);
+    delete this[key];
   }
 }
 

--- a/packages/app/src/systems/Account/__mocks__/accounts.tsx
+++ b/packages/app/src/systems/Account/__mocks__/accounts.tsx
@@ -4,7 +4,7 @@ import { Wallet } from 'fuels';
 import { AccountService } from '../services';
 import { IndexedDBStorage } from '../utils';
 
-import { db } from '~/systems/Core';
+import { db, Storage } from '~/systems/Core';
 
 const wallet1 = Wallet.generate();
 const wallet2 = Wallet.generate();
@@ -71,6 +71,11 @@ export async function createMockAccount() {
       publicKey: walletAccount.publicKey,
     },
   });
+
+  /**
+   * Set account as logged
+   */
+  Storage.setItem('isLogged', true);
 
   return { account, password, manager };
 }

--- a/packages/app/src/systems/Account/events.tsx
+++ b/packages/app/src/systems/Account/events.tsx
@@ -29,5 +29,10 @@ export function accountEvents(store: StoreClass<StoreMachines>) {
         input,
       });
     },
+    logout() {
+      store.send(Services.accounts, {
+        type: 'LOGOUT',
+      });
+    },
   };
 }

--- a/packages/app/src/systems/Account/hooks/useAccounts.tsx
+++ b/packages/app/src/systems/Account/hooks/useAccounts.tsx
@@ -92,6 +92,9 @@ export function useAccounts() {
       redirectToHome() {
         navigate(Pages.wallet());
       },
+      refreshApplication() {
+        window.location.reload();
+      },
     },
   });
 
@@ -119,6 +122,7 @@ export function useAccounts() {
       goToAdd,
       unlock,
       closeUnlock,
+      logout: store.logout,
       hideAccount: store.hideAccount,
       selectAccount: store.selectAccount,
       addAccount: store.addAccount,

--- a/packages/app/src/systems/Account/machines/accountMachine.test.ts
+++ b/packages/app/src/systems/Account/machines/accountMachine.test.ts
@@ -27,6 +27,7 @@ const machine = accountMachine.withContext({}).withConfig({
   actions: {
     notifyUpdateAccounts() {},
     redirectToHome() {},
+    refreshApplication() {},
   },
 });
 

--- a/packages/app/src/systems/Account/machines/accountMachine.test.ts
+++ b/packages/app/src/systems/Account/machines/accountMachine.test.ts
@@ -7,6 +7,7 @@ import { AccountService } from '../services';
 import type { AccountMachineService, MachineEvents } from './accountMachine';
 import { accountMachine } from './accountMachine';
 
+import { db, Storage } from '~/systems/Core';
 import { expectStateMatch } from '~/systems/Core/__tests__/utils';
 
 const MOCK_ACCOUNT = {
@@ -149,6 +150,25 @@ describe('accountsMachine', () => {
         },
       });
       await expectStateMatch(service, 'failed');
+    });
+
+    it('logout should clean indexdb and localstorage', async () => {
+      await createMockAccount();
+
+      // Check if indexdb is not empty
+      const accountsBefore = await AccountService.getAccounts();
+      expect(accountsBefore.length).toBeGreaterThanOrEqual(1);
+
+      // Execute logout
+      await expectStateMatch(service, 'idle');
+      service.send('LOGOUT');
+      await db.open();
+
+      // Check if indexdb is empty
+      const accountsAfter = await AccountService.getAccounts();
+      const isLogged = Storage.getItem('isLogged');
+      expect(accountsAfter.length).toBe(0);
+      expect(isLogged).toBe(null);
     });
   });
 });

--- a/packages/app/src/systems/Account/pages/Logout/Logout.stories.tsx
+++ b/packages/app/src/systems/Account/pages/Logout/Logout.stories.tsx
@@ -1,0 +1,29 @@
+import type { Meta, StoryFn } from '@storybook/react';
+
+import { AccountService, MOCK_ACCOUNTS } from '../..';
+
+import { Logout } from './Logout';
+
+import { store } from '~/store';
+
+export default {
+  component: Logout,
+  title: 'Account/Pages/3. Logout',
+  parameters: {
+    layout: 'fullscreen',
+    viewport: {
+      defaultViewport: 'chromeExtension',
+    },
+  },
+} as Meta;
+
+export const Usage: StoryFn<unknown> = () => <Logout />;
+Usage.loaders = [
+  async () => {
+    await AccountService.clearAccounts();
+    await AccountService.addAccount({ data: MOCK_ACCOUNTS[0] });
+    await AccountService.addAccount({ data: MOCK_ACCOUNTS[1] });
+    store.reset();
+    return {};
+  },
+];

--- a/packages/app/src/systems/Account/pages/Logout/Logout.tsx
+++ b/packages/app/src/systems/Account/pages/Logout/Logout.tsx
@@ -1,0 +1,54 @@
+import { Button, Card, Icon, Text } from '@fuel-ui/react';
+import { useNavigate } from 'react-router-dom';
+
+import { useAccounts } from '../../hooks';
+
+import { Layout, Pages } from '~/systems/Core';
+
+export const Logout = () => {
+  const navigate = useNavigate();
+  const { isLoading, handlers } = useAccounts();
+
+  return (
+    <Layout title="Logout" isLoading={isLoading}>
+      <Layout.TopBar onBack={() => navigate(Pages.wallet())} />
+      <Layout.Content>
+        <Card css={{ padding: '$4' }}>
+          <Text
+            as="h2"
+            color="gray12"
+            leftIcon={<Icon icon={Icon.is('Warning')} color="yellow12" />}
+            css={{ mb: '$4' }}
+          >
+            IMPORTANT
+          </Text>
+          <Text color="gray11" css={{ mb: '$2' }}>
+            This action will remove all data from this device, including your
+            seedphrase and accounts.
+          </Text>
+          <Text color="gray11" css={{ mb: '$2' }}>
+            Make sure you have securely backed up your seed phrase before
+            removing the wallet.
+          </Text>
+          <Text color="gray11" css={{ mb: '$2' }}>
+            If you have not backed up your seed phrase, you will lose access to
+            your funds.
+          </Text>
+          <Text color="gray11" css={{ mb: '$2' }}></Text>
+        </Card>
+      </Layout.Content>
+      <Layout.BottomBar>
+        <Button
+          aria-label="Logout"
+          onPress={handlers.logout}
+          isLoading={isLoading}
+          isDisabled={isLoading}
+          variant="ghost"
+          color="red"
+        >
+          Logout
+        </Button>
+      </Layout.BottomBar>
+    </Layout>
+  );
+};

--- a/packages/app/src/systems/Account/pages/Logout/index.tsx
+++ b/packages/app/src/systems/Account/pages/Logout/index.tsx
@@ -1,0 +1,1 @@
+export * from './Logout';

--- a/packages/app/src/systems/Account/pages/index.tsx
+++ b/packages/app/src/systems/Account/pages/index.tsx
@@ -1,2 +1,3 @@
 export * from './Accounts';
 export * from './AddAccount';
+export * from './Logout';

--- a/packages/app/src/systems/Account/routes.tsx
+++ b/packages/app/src/systems/Account/routes.tsx
@@ -2,11 +2,12 @@ import { Route } from 'react-router-dom';
 
 import { Pages } from '../Core/types';
 
-import { Accounts, AddAccount } from './pages';
+import { Accounts, AddAccount, Logout } from './pages';
 
 export const accountRoutes = (
   <Route path={Pages.accounts()}>
     <Route index element={<Accounts />} />
     <Route path={Pages.accountAdd()} element={<AddAccount />} />
+    <Route path={Pages.logout()} element={<Logout />} />
   </Route>
 );

--- a/packages/app/src/systems/Account/services/account.ts
+++ b/packages/app/src/systems/Account/services/account.ts
@@ -8,6 +8,7 @@ import { Address, bn, Provider } from 'fuels';
 import { unlockManager } from '../utils/manager';
 
 import { isEth } from '~/systems/Asset/utils/asset';
+import { Storage } from '~/systems/Core';
 import type { Maybe } from '~/systems/Core/types';
 import { db } from '~/systems/Core/utils/database';
 import { getPhraseFromValue } from '~/systems/Core/utils/string';
@@ -275,6 +276,12 @@ export class AccountService {
     return accounts.filter((account) =>
       account.name.toLowerCase().includes(name.toLowerCase())
     );
+  }
+
+  static async logout() {
+    await db.close();
+    await db.delete();
+    await Storage.clear();
   }
 }
 

--- a/packages/app/src/systems/Account/services/account.ts
+++ b/packages/app/src/systems/Account/services/account.ts
@@ -3,14 +3,15 @@ import type { WalletUnlocked } from '@fuel-ts/wallet';
 import { WalletLocked } from '@fuel-ts/wallet';
 import type { WalletManager } from '@fuel-ts/wallet-manager';
 import type { Account } from '@fuel-wallet/types';
+import Dexie from 'dexie';
 import { Address, bn, Provider } from 'fuels';
 
 import { unlockManager } from '../utils/manager';
 
 import { isEth } from '~/systems/Asset/utils/asset';
-import { Storage } from '~/systems/Core';
 import type { Maybe } from '~/systems/Core/types';
 import { db } from '~/systems/Core/utils/database';
+import { Storage } from '~/systems/Core/utils/storage';
 import { getPhraseFromValue } from '~/systems/Core/utils/string';
 import { NetworkService } from '~/systems/Network/services';
 
@@ -280,7 +281,7 @@ export class AccountService {
 
   static async logout() {
     await db.close();
-    await db.delete();
+    await Dexie.delete('FuelDB');
     await Storage.clear();
   }
 }

--- a/packages/app/src/systems/Core/types.ts
+++ b/packages/app/src/systems/Core/types.ts
@@ -36,6 +36,7 @@ export const Pages = {
   sendConfirm: route('/send/confirm'),
   accounts: route('/accounts'),
   accountAdd: route('/accounts/add'),
+  logout: route('/accounts/logout'),
 };
 
 export type AmountMap = Record<string, Maybe<BN>>;

--- a/packages/app/src/systems/Sidebar/components/Sidebar/Sidebar.tsx
+++ b/packages/app/src/systems/Sidebar/components/Sidebar/Sidebar.tsx
@@ -1,7 +1,6 @@
 import { cssObj } from '@fuel-ui/css';
 import { Icon, Box, Avatar, Flex, Drawer, IconButton } from '@fuel-ui/react';
 
-import type { MenuItemObj } from '..';
 import { Menu, NetworkSelector } from '..';
 import { useAccounts } from '../../../Account';
 import { NetworkScreen, useNetworks } from '../../../Network';
@@ -41,7 +40,7 @@ export function Sidebar() {
             aria-label="drawer_closeButton"
           />
         </Flex>
-        <Menu items={sidebarItems as MenuItemObj[]} />
+        <Menu items={sidebarItems} />
       </Flex>
       <Flex
         css={{

--- a/packages/app/src/systems/Sidebar/constants/sidebarItems.ts
+++ b/packages/app/src/systems/Sidebar/constants/sidebarItems.ts
@@ -1,11 +1,19 @@
+import type { MenuItemObj } from '../components';
+
 import { Pages } from '~/systems/Core';
 
-export const sidebarItems = [
+export const sidebarItems: Array<MenuItemObj> = [
   {
     key: 'wallet',
     icon: 'Wallet',
     label: 'Wallet',
     path: Pages.wallet(),
+  },
+  {
+    key: 'connected-apps',
+    icon: 'PlugsConnected',
+    label: 'Connected Apps',
+    path: Pages.settingsConnectedApps(),
   },
   {
     key: 'settings',
@@ -25,10 +33,10 @@ export const sidebarItems = [
         path: Pages.settingsChangePassword(),
       },
       {
-        key: 'connected-apps',
-        icon: 'PlugsConnected',
-        label: 'Connected Apps',
-        path: Pages.settingsConnectedApps(),
+        key: 'logout',
+        icon: 'SignOut',
+        label: 'Logout',
+        path: Pages.logout(),
       },
     ],
   },


### PR DESCRIPTION
Add logout feature to Wallet. This action deletes all storage. I also added an intermediary page with warning content to confirm that users had backed up the seed phrase and the risk of deleting it.

closes: #380 