### PR TITLE
chore: add retry to jest tests

### DIFF
--- a/packages/app/jest.setup.ts
+++ b/packages/app/jest.setup.ts
@@ -13,3 +13,8 @@ const noop = () => {};
 Object.defineProperty(window, 'scrollTo', { value: noop, writable: true });
 Object.defineProperty(window, 'localStorage', { value: localStorageMock });
 Object.defineProperty(window, 'crypto', { value: webcrypto });
+
+// If test fails retry it until success
+jest.retryTimes(3, {
+  logErrorsBeforeRetry: true,
+});


### PR DESCRIPTION
When jest fails retry just the failed tests, this will avoid the need to manually retry tests.