### PR TITLE
feat: add address based feature for signMessage and sendTransaction

### DIFF
--- a/packages/app/src/systems/Account/services/account.ts
+++ b/packages/app/src/systems/Account/services/account.ts
@@ -29,6 +29,9 @@ export type AccountInputs = {
     providerUrl: string;
     account?: Maybe<Account>;
   };
+  fetchAccount: {
+    address: string;
+  };
   setBalance: {
     data: Pick<Account, 'address' | 'balance' | 'balanceSymbol' | 'balances'>;
   };
@@ -91,6 +94,19 @@ export class AccountService {
     return db.transaction('rw', db.accounts, async () => {
       return db.accounts.clear();
     });
+  }
+
+  static async fetchAccount(input: AccountInputs['fetchAccount']) {
+    const { address } = input;
+    const account = await db.transaction('r', db.accounts, async () => {
+      return db.accounts.get({ address });
+    });
+
+    if (!account) {
+      throw new Error('Account not found!');
+    }
+
+    return account;
   }
 
   static async fetchBalance(input: AccountInputs['fetchBalance']) {

--- a/packages/app/src/systems/CRX/background/services/BackgroundService.ts
+++ b/packages/app/src/systems/CRX/background/services/BackgroundService.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { CONTENT_SCRIPT_NAME, MessageTypes } from '@fuel-wallet/types';
-import type { FuelProviderConfig, Connection } from '@fuel-wallet/types';
+import type { Connection } from '@fuel-wallet/types';
 import { Address } from 'fuels';
 import type {
   JSONRPCParams,
@@ -214,27 +214,22 @@ export class BackgroundService {
   }
 
   async sendTransaction(
-    {
-      provider,
-      transaction,
-      address,
-    }: { provider: FuelProviderConfig; transaction: string; address: string },
+    input: Exclude<MessageInputs['sendTransaction'], 'origin'>,
     serverParams: EventOrigin
   ) {
     const origin = serverParams.origin;
 
-    await this.requireAccountConnecton(serverParams.connection, address);
+    await this.requireAccountConnecton(serverParams.connection, input.address);
 
     const popupService = await PopUpService.open(
       origin,
       Pages.requestTransaction(),
       this.communicationProtocol
     );
-    const signedMessage = await popupService.sendTransaction(
+    const signedMessage = await popupService.sendTransaction({
+      ...input,
       origin,
-      provider,
-      transaction
-    );
+    });
     return signedMessage;
   }
 

--- a/packages/app/src/systems/CRX/background/services/BackgroundService.ts
+++ b/packages/app/src/systems/CRX/background/services/BackgroundService.ts
@@ -11,6 +11,7 @@ import { JSONRPCServer } from 'json-rpc-2.0';
 
 import type { CommunicationProtocol } from './CommunicationProtocol';
 import { PopUpService } from './PopUpService';
+import type { MessageInputs } from './types';
 
 import { AccountService } from '~/systems/Account/services';
 import { Pages } from '~/systems/Core/types';
@@ -193,19 +194,22 @@ export class BackgroundService {
   }
 
   async signMessage(
-    { message, address }: { message: string; address: string },
+    input: Exclude<MessageInputs['signMessage'], 'origin'>,
     serverParams: EventOrigin
   ) {
     const origin = serverParams.origin;
 
-    await this.requireAccountConnecton(serverParams.connection, address);
+    await this.requireAccountConnecton(serverParams.connection, input.address);
 
     const popupService = await PopUpService.open(
       origin,
       Pages.requestMessage(),
       this.communicationProtocol
     );
-    const signedMessage = await popupService.signMessage(origin, message);
+    const signedMessage = await popupService.signMessage({
+      ...input,
+      origin,
+    });
     return signedMessage;
   }
 

--- a/packages/app/src/systems/CRX/background/services/PopUpService.ts
+++ b/packages/app/src/systems/CRX/background/services/PopUpService.ts
@@ -1,9 +1,5 @@
 import { POPUP_SCRIPT_NAME, MessageTypes } from '@fuel-wallet/types';
-import type {
-  FuelProviderConfig,
-  ResponseMessage,
-  UIEventMessage,
-} from '@fuel-wallet/types';
+import type { ResponseMessage, UIEventMessage } from '@fuel-wallet/types';
 import { JSONRPCClient } from 'json-rpc-2.0';
 
 import {
@@ -143,27 +139,19 @@ export class PopUpService {
     return this.client.request('signMessage', input);
   }
 
-  async sendTransaction(
-    origin: string,
-    provider: FuelProviderConfig,
-    transaction: string
-  ) {
+  async sendTransaction(input: MessageInputs['sendTransaction']) {
     const selectedNetwork = await NetworkService.getSelectedNetwork();
-    if (selectedNetwork?.url !== provider.url) {
+    if (selectedNetwork?.url !== input.provider.url) {
       // TODO: Show for the user to add new network before
       // finishing the transaction
       // https://github.com/FuelLabs/fuels-wallet/issues/200
       throw new Error(
         [
-          `${provider.url} is different from the user current network!`,
+          `${input.provider.url} is different from the user current network!`,
           'Request the user to add the new network. fuel.addNetwork([...]).',
         ].join('\n')
       );
     }
-    return this.client.request('sendTransaction', {
-      origin,
-      transaction,
-      provider,
-    });
+    return this.client.request('sendTransaction', input);
   }
 }

--- a/packages/app/src/systems/CRX/background/services/PopUpService.ts
+++ b/packages/app/src/systems/CRX/background/services/PopUpService.ts
@@ -16,6 +16,7 @@ import type { DeferPromise } from '../../utils/promise';
 import { deferPromise } from '../../utils/promise';
 
 import type { CommunicationProtocol } from './CommunicationProtocol';
+import type { MessageInputs } from './types';
 
 import { CRXPages } from '~/systems/Core/types';
 import { NetworkService } from '~/systems/Network/services';
@@ -138,8 +139,8 @@ export class PopUpService {
     return this.client.request('requestConnection', { origin });
   }
 
-  async signMessage(origin: string, message: string) {
-    return this.client.request('signMessage', { origin, message });
+  async signMessage(input: MessageInputs['signMessage']) {
+    return this.client.request('signMessage', input);
   }
 
   async sendTransaction(

--- a/packages/app/src/systems/CRX/background/services/types.ts
+++ b/packages/app/src/systems/CRX/background/services/types.ts
@@ -1,0 +1,7 @@
+export type MessageInputs = {
+  signMessage: {
+    message: string;
+    address: string;
+    origin: string;
+  };
+};

--- a/packages/app/src/systems/CRX/background/services/types.ts
+++ b/packages/app/src/systems/CRX/background/services/types.ts
@@ -1,7 +1,15 @@
+import type { FuelProviderConfig } from '@fuel-wallet/types';
+
 export type MessageInputs = {
   signMessage: {
     message: string;
     address: string;
     origin: string;
+  };
+  sendTransaction: {
+    address: string;
+    origin: string;
+    provider: FuelProviderConfig;
+    transaction: string;
   };
 };

--- a/packages/app/src/systems/CRX/scripts/pageScript.ts
+++ b/packages/app/src/systems/CRX/scripts/pageScript.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 // @ts-nocheck
-import { injectFuel } from '@fuel-wallet/sdk/dist';
+import { injectFuel } from '@fuel-wallet/sdk';
 
 injectFuel(window);

--- a/packages/app/src/systems/CRX/scripts/pageScript.ts
+++ b/packages/app/src/systems/CRX/scripts/pageScript.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 // @ts-nocheck
-import { injectFuel } from '@fuel-wallet/sdk';
+import { injectFuel } from '@fuel-wallet/sdk/dist';
 
 injectFuel(window);

--- a/packages/app/src/systems/DApp/hooks/useSignatureRequest.tsx
+++ b/packages/app/src/systems/DApp/hooks/useSignatureRequest.tsx
@@ -4,9 +4,8 @@ import type { SignMachineState } from '../machines';
 import { signMachine } from '../machines';
 import { useSignRequestMethods } from '../methods';
 
-import { useAccounts } from '~/systems/Account';
-
 const selectors = {
+  account: (state: SignMachineState) => state.context.account,
   origin: (state: SignMachineState) => state.context.origin,
   unlockError: (state: SignMachineState) => state.context.unlockError,
   message: (state: SignMachineState) => state.context.message,
@@ -17,7 +16,6 @@ const selectors = {
 };
 
 export function useSignatureRequest() {
-  const { account } = useAccounts();
   const service = useInterpret(
     signMachine.withConfig({
       actions: {
@@ -34,6 +32,7 @@ export function useSignatureRequest() {
   const message = useSelector(service, selectors.message);
   const unlockError = useSelector(service, selectors.unlockError);
   const origin = useSelector(service, selectors.origin);
+  const account = useSelector(service, selectors.account);
 
   // Start Connect Request Methods
   useSignRequestMethods(service);

--- a/packages/app/src/systems/DApp/hooks/useTransactionRequest.tsx
+++ b/packages/app/src/systems/DApp/hooks/useTransactionRequest.tsx
@@ -9,7 +9,6 @@ import {
 } from '../machines/transactionMachine';
 import { useTransactionRequestMethods } from '../methods/transactionRequestMethods';
 
-import { useAccounts } from '~/systems/Account';
 import { isEth } from '~/systems/Asset';
 import { useChainInfo } from '~/systems/Network';
 import { getFilteredErrors, TxStatus } from '~/systems/Transaction';
@@ -20,8 +19,14 @@ const selectors = {
   context(state: TransactionMachineState) {
     return state.context;
   },
+  account(state: TransactionMachineState) {
+    return state.context.input.account;
+  },
   isUnlocking(state: TransactionMachineState) {
     return state.children.unlock?.state.matches('unlocking');
+  },
+  isLoadingAccounts(state: TransactionMachineState) {
+    return state.matches('fetchingAccount');
   },
   errors(state: TransactionMachineState) {
     if (!state.context.errors) return {};
@@ -67,7 +72,6 @@ export type UseTransactionRequestReturn = ReturnType<
 >;
 
 export function useTransactionRequest(opts: UseTransactionRequestOpts = {}) {
-  const { account, isLoading: isLoadingAccounts } = useAccounts();
   const service = useInterpret(() =>
     transactionMachine
       .withConfig({
@@ -84,6 +88,8 @@ export function useTransactionRequest(opts: UseTransactionRequestOpts = {}) {
       })
   );
 
+  const isLoadingAccounts = useSelector(service, selectors.isLoadingAccounts);
+  const account = useSelector(service, selectors.account);
   const ctx = useSelector(service, selectors.context);
   const errors = useSelector(service, selectors.errors);
   const providerUrl = ctx.input.providerUrl;

--- a/packages/app/src/systems/DApp/machines/signMachine.test.tsx
+++ b/packages/app/src/systems/DApp/machines/signMachine.test.tsx
@@ -19,6 +19,13 @@ describe('signMachine', () => {
 
   beforeAll(async () => {
     wallet = Wallet.fromPrivateKey(OWNER);
+    jest.spyOn(AccountService, 'fetchAccount').mockResolvedValue(
+      Promise.resolve({
+        name: 'Account 1',
+        address: wallet.address.toString(),
+        publicKey: wallet.publicKey,
+      })
+    );
     jest.spyOn(AccountService, 'unlock').mockResolvedValue(wallet);
   });
 
@@ -36,6 +43,7 @@ describe('signMachine', () => {
     const DATA = {
       origin: 'foo.com',
       message: 'test message',
+      address: wallet.address.toString(),
     };
     await waitFor(service, (state) => state.matches('idle'));
 
@@ -71,6 +79,7 @@ describe('signMachine', () => {
       input: {
         origin: 'foo.com',
         message: 'test message',
+        address: wallet.address.toString(),
       },
     });
 

--- a/packages/app/src/systems/DApp/machines/transactionMachine.test.tsx
+++ b/packages/app/src/systems/DApp/machines/transactionMachine.test.tsx
@@ -22,6 +22,13 @@ describe('txApproveMachine', () => {
 
   beforeAll(async () => {
     wallet = Wallet.fromPrivateKey(OWNER);
+    jest.spyOn(AccountService, 'fetchAccount').mockResolvedValue(
+      Promise.resolve({
+        name: 'Account 1',
+        address: wallet.address.toString(),
+        publicKey: wallet.publicKey,
+      })
+    );
     jest.spyOn(AccountService, 'unlock').mockResolvedValue(wallet);
     transactionRequest = await getMockedTransaction(
       wallet?.publicKey || '',
@@ -45,7 +52,12 @@ describe('txApproveMachine', () => {
   it('should approve/send transaction', async () => {
     await waitFor(service, (state) => state.matches('idle'));
     service.send('START_REQUEST', {
-      input: { transactionRequest, providerUrl, origin: 'foo.com' },
+      input: {
+        transactionRequest,
+        providerUrl,
+        origin: 'foo.com',
+        address: wallet.address.toString(),
+      },
     });
 
     await waitFor(service, (state) => state.matches('simulatingTransaction'));

--- a/packages/app/src/systems/DApp/methods/signRequestMethods.ts
+++ b/packages/app/src/systems/DApp/methods/signRequestMethods.ts
@@ -4,6 +4,7 @@ import { useEffect } from 'react';
 import type { SignMachineService } from '../machines';
 
 import { IS_CRX_POPUP } from '~/config';
+import type { MessageInputs } from '~/systems/CRX/background/services/types';
 import { waitForState } from '~/systems/Core';
 
 export class SignRequestMethods extends ExtensionPageConnection {
@@ -19,9 +20,9 @@ export class SignRequestMethods extends ExtensionPageConnection {
     return new SignRequestMethods(service);
   }
 
-  async signMessage({ origin, message }: { origin: string; message: string }) {
+  async signMessage(input: MessageInputs['signMessage']) {
     this.service.send('START_SIGN', {
-      input: { origin, message },
+      input,
     });
     const state = await waitForState(this.service);
     return state.signedMessage;

--- a/packages/app/src/systems/DApp/methods/transactionRequestMethods.ts
+++ b/packages/app/src/systems/DApp/methods/transactionRequestMethods.ts
@@ -1,11 +1,11 @@
 import { ExtensionPageConnection } from '@fuel-wallet/sdk';
-import type { FuelProviderConfig } from '@fuel-wallet/types';
 import { transactionRequestify } from 'fuels';
 import { useEffect } from 'react';
 
 import type { TransactionMachineService } from '../machines/transactionMachine';
 
 import { IS_CRX_POPUP } from '~/config';
+import type { MessageInputs } from '~/systems/CRX/background/services/types';
 import { waitForState } from '~/systems/Core';
 
 export class TransactionRequestMethods extends ExtensionPageConnection {
@@ -21,19 +21,13 @@ export class TransactionRequestMethods extends ExtensionPageConnection {
     return new TransactionRequestMethods(service);
   }
 
-  async sendTransaction({
-    origin,
-    provider,
-    transaction,
-  }: {
-    origin: string;
-    provider: FuelProviderConfig;
-    transaction: string;
-  }) {
+  async sendTransaction(input: MessageInputs['sendTransaction']) {
+    const { origin, address, provider, transaction } = input;
     const providerUrl = provider.url;
     const transactionRequest = transactionRequestify(JSON.parse(transaction));
-    const input = { origin, transactionRequest, providerUrl };
-    this.service.send('START_REQUEST', { input });
+    this.service.send('START_REQUEST', {
+      input: { origin, transactionRequest, address, providerUrl },
+    });
     const state = await waitForState(this.service, 'txSuccess');
     return state.response?.approvedTx?.id;
   }

--- a/packages/app/src/systems/DApp/pages/ConnectionRequest/ConnectionRequest.tsx
+++ b/packages/app/src/systems/DApp/pages/ConnectionRequest/ConnectionRequest.tsx
@@ -65,13 +65,14 @@ export function ConnectionRequest() {
                 </Flex>
               </motion.div>
               {accounts?.map((account) => {
-                const { address } = account;
+                const { address, name } = account;
                 const isConnected = handlers.isAccountSelected(address);
                 const rightEl = (
                   <Flex css={styles.switchWrapper}>
                     <Switch
                       size="sm"
                       checked={isConnected}
+                      aria-label={`Toggle ${name}`}
                       onCheckedChange={() => handlers.toggleAccount(address)}
                     />
                   </Flex>

--- a/packages/app/src/systems/DApp/pages/SignatureRequest/SignatureRequest.tsx
+++ b/packages/app/src/systems/DApp/pages/SignatureRequest/SignatureRequest.tsx
@@ -19,7 +19,7 @@ export function SignatureRequest() {
     isUnlockingLoading,
   } = useSignatureRequest();
 
-  if (!origin || !message) return null;
+  if (!origin || !message || !account) return null;
 
   return (
     <>

--- a/packages/app/src/systems/DApp/pages/TransactionRequest/TransactionRequest.tsx
+++ b/packages/app/src/systems/DApp/pages/TransactionRequest/TransactionRequest.tsx
@@ -11,6 +11,7 @@ import { TxContent, TxHeader } from '~/systems/Transaction';
 export function TransactionRequest() {
   const txRequest = useTransactionRequest({ isOriginRequired: true });
   const { handlers, status, ...ctx } = txRequest;
+
   if (!ctx.account) return null;
 
   return (

--- a/packages/app/src/systems/Send/__mocks__/send.tsx
+++ b/packages/app/src/systems/Send/__mocks__/send.tsx
@@ -18,16 +18,17 @@ export function sendLoader(wallet: WalletUnlocked) {
       wallet.publicKey,
       network?.url!
     );
-    return { acc1, network, transactionRequest };
+    return { acc1, network, transactionRequest, address: acc1?.address };
   };
 }
 
 export function useTxRequestMock(loaded: any) {
-  const { transactionRequest, network } = loaded || {};
+  const { transactionRequest, network, address } = loaded || {};
   const txRequest = useTransactionRequest();
 
   useEffect(() => {
     txRequest.handlers.request({
+      address,
       transactionRequest,
       providerUrl: network?.url,
     });

--- a/packages/app/src/systems/Send/components/SendSelect/SendSelect.tsx
+++ b/packages/app/src/systems/Send/components/SendSelect/SendSelect.tsx
@@ -14,6 +14,7 @@ type SendSelectProps = UseSendReturn;
 
 export function SendSelect({
   form,
+  account,
   txRequest,
   handlers,
   ...ctx
@@ -31,7 +32,7 @@ export function SendSelect({
             control={form.control}
             render={({ field }) => (
               <AssetSelect
-                items={txRequest.account?.balances}
+                items={account?.balances}
                 selected={ASSET_MAP[field.value]}
                 onSelect={(asset) => {
                   // eslint-disable-next-line @typescript-eslint/no-non-null-asserted-optional-chain

--- a/packages/app/src/systems/Send/hooks/useSend.tsx
+++ b/packages/app/src/systems/Send/hooks/useSend.tsx
@@ -115,7 +115,7 @@ export function useSend() {
   const isInvalid = useSelector(service, selectors.isInvalid);
   const titleSelector = selectors.title(txRequest.txStatus);
   const title = useSelector(service, titleSelector);
-  const accountBalance = bn(txRequest.account?.balance);
+  const accountBalance = bn(account?.balance);
   const maxAmountToSend = accountBalance.sub(fee!);
 
   function status(status: keyof typeof SendStatus) {
@@ -178,6 +178,7 @@ export function useSend() {
     title,
     status,
     isInvalid,
+    account,
     accountBalance,
     txRequest,
     handlers: {

--- a/packages/app/src/systems/Send/machines/sendMachine.ts
+++ b/packages/app/src/systems/Send/machines/sendMachine.ts
@@ -146,6 +146,7 @@ export const sendMachine = createMachine(
           });
 
           return {
+            address: wallet.address.toString(),
             transactionRequest,
             providerUrl: network.url,
           };

--- a/packages/app/src/systems/Transaction/services/transaction.tsx
+++ b/packages/app/src/systems/Transaction/services/transaction.tsx
@@ -37,6 +37,7 @@ export type TxInputs = {
     id: string;
   };
   request: {
+    address?: string;
     origin?: string;
     transactionRequest: TransactionRequest;
     providerUrl: string;


### PR DESCRIPTION
Add address-based `signMessage` and sendTransaction feature, with this PR it will be possible to execute actions with a different wallet that is not currently selected.

- Update machines `tranasactionRequest` and `signatureRequest`
   - Add address param on start machine actions.
   - Add a new state fetchAccount to query the account by the address
   - On `tranasactionRequest` also add fetch balances as required it.
- Update machine `sendMachine`
  -  To inform the address before starting the `transactionRequest` machine.
- Add E2E tests for this
- Fix machine tests to inform the address

close: #495 