### PR TITLE
fix: pass signer from wallet

### DIFF
--- a/.changeset/wet-gifts-love.md
+++ b/.changeset/wet-gifts-love.md
@@ -1,0 +1,5 @@
+---
+"@fuel-wallet/sdk": minor
+---
+
+Add FuelWalletLocked on the fuel instance and fix issue with detect siner

--- a/packages/docs/docs/api.mdx
+++ b/packages/docs/docs/api.mdx
@@ -58,8 +58,8 @@ sign, and send the transaction.
 
 ### Get Wallet
 
-`getWallet(address: string | AbstractAddress): Promise<WalletLocked>`<br />
-Return `WalletLocked` using a FuelWalletProvider on the connection point to request signed actions.
+`getWallet(address: string | AbstractAddress): Promise<FuelWalletLocked>`<br />
+Return `FuelWalletLocked` using a FuelWalletProvider on the connection point to request signed actions.
 
 <CodeImport file="../../sdk/src/Fuel.test.ts" testCase="getWallet" />
 

--- a/packages/docs/docs/how-to-use.mdx
+++ b/packages/docs/docs/how-to-use.mdx
@@ -45,7 +45,7 @@ You can also get the current account being used in the wallet using `window.fuel
 
 With access to the user address and the connection authorized, you can request the user's signature using `fuel.signMessage`.
 
-<CodeImport file="../examples/SignMessage.tsx" lineStart="20" lineEnd="23" />
+<CodeImport file="../examples/SignMessage.tsx" lineStart="20" lineEnd="24" />
 
 <Examples.SignMessage />
 
@@ -53,6 +53,6 @@ With access to the user address and the connection authorized, you can request t
 
 To transfer an amount to other address, use the `wallet.transfer` method and pass in the address you want to send to and the amount to send.
 
-<CodeImport file="../examples/Transfer.tsx" lineStart="36" lineEnd="40" />
+<CodeImport file="../examples/Transfer.tsx" lineStart="36" lineEnd="41" />
 
 <Examples.Transfer />

--- a/packages/docs/examples/SignMessage.tsx
+++ b/packages/docs/examples/SignMessage.tsx
@@ -19,7 +19,8 @@ export function SignMessage() {
       console.debug('Request signature of message!');
       const accounts = await fuel.accounts();
       const account = accounts[0];
-      const signedMessage = await fuel.signMessage(account, message);
+      const wallet = await fuel.getWallet(account);
+      const signedMessage = await wallet.signMessage(message);
       console.debug('Message signature', signedMessage);
       setSignedMessage(signedMessage);
     }

--- a/packages/sdk/src/Fuel.ts
+++ b/packages/sdk/src/Fuel.ts
@@ -1,7 +1,8 @@
-import { Address, WalletLocked } from 'fuels';
+import { Address } from 'fuels';
 import type { AbstractAddress } from 'fuels';
 
 import { FuelWalletConnection } from './FuelWalletConnection';
+import { FuelWalletLocked } from './FuelWalletLocked';
 import { FuelWalletProvider } from './FuelWalletProvider';
 
 // Isolate the provider instance to prevent
@@ -47,9 +48,11 @@ export class Fuel extends FuelWalletConnection {
     return FuelWeb3Privates.provider;
   }
 
-  async getWallet(address: string | AbstractAddress): Promise<WalletLocked> {
+  async getWallet(
+    address: string | AbstractAddress
+  ): Promise<FuelWalletLocked> {
     const provider = await this.getProvider();
-    return new WalletLocked(address, provider);
+    return new FuelWalletLocked(address, provider);
   }
 }
 

--- a/packages/sdk/src/FuelWalletConnection.ts
+++ b/packages/sdk/src/FuelWalletConnection.ts
@@ -68,7 +68,7 @@ export class FuelWalletConnection extends WindowConnection {
   }
 
   async sendTransaction(
-    transaction: TransactionRequestLike,
+    transaction: TransactionRequestLike & { signer?: string },
     providerConfig: FuelProviderConfig,
     signer?: string
   ): Promise<string> {
@@ -76,7 +76,8 @@ export class FuelWalletConnection extends WindowConnection {
       throw new Error('Transaction is required');
     }
 
-    const address = signer || getTransactionSigner(transaction);
+    const address =
+      signer || transaction.signer || getTransactionSigner(transaction);
 
     return this.client.request('sendTransaction', {
       address,

--- a/packages/sdk/src/FuelWalletLocked.ts
+++ b/packages/sdk/src/FuelWalletLocked.ts
@@ -1,0 +1,33 @@
+import type {
+  AbstractAddress,
+  TransactionRequestLike,
+  TransactionResponse,
+} from 'fuels';
+import { WalletLocked } from 'fuels';
+
+import type { FuelWalletProvider } from './FuelWalletProvider';
+
+export class FuelWalletLocked extends WalletLocked {
+  provider: FuelWalletProvider;
+
+  constructor(address: string | AbstractAddress, provider: FuelWalletProvider) {
+    super(address, provider);
+    this.provider = provider;
+  }
+
+  async signMessage(message: string): Promise<string> {
+    return this.provider.walletConnection.signMessage(
+      this.address.toString(),
+      message
+    );
+  }
+
+  async sendTransaction(
+    transaction: TransactionRequestLike
+  ): Promise<TransactionResponse> {
+    return this.provider.sendTransaction({
+      ...transaction,
+      signer: this.address.toString(),
+    });
+  }
+}

--- a/packages/sdk/src/FuelWalletProvider.ts
+++ b/packages/sdk/src/FuelWalletProvider.ts
@@ -12,7 +12,7 @@ export class FuelWalletProvider extends Provider {
   }
 
   async sendTransaction(
-    transactionRequestLike: TransactionRequestLike
+    transactionRequestLike: TransactionRequestLike & { signer?: string }
   ): Promise<TransactionResponse> {
     const transactionId = await this.walletConnection.sendTransaction(
       transactionRequestLike,


### PR DESCRIPTION
When doing a transaction without previously adding coins, the current solution could not detect the signer. For this, I have created a FuelWalletLocked that implements the sendTransaction and passes the provider the signer on the tx payload.

As we now have a custom wallet, I also add a sign message method to the instance of the wallet.

This PR;
- Adds a custom WalletLocked instance to the fuel instance.
- Adds docs using the `signMessage` from the FuelWalletLocked.