### PR TITLE
fix: home redirect, source code link and code import

### DIFF
--- a/packages/docs/docs/contributing/running-locally.mdx
+++ b/packages/docs/docs/contributing/running-locally.mdx
@@ -65,27 +65,27 @@ pnpm dev
 
 This section has a brief description of each directory. More details can be found inside each package, by clicking on the links.
 
-- [packages/app](../packages/app/) Frontend Fuel Wallet application
-- [packages/config](../packages/config/) Build configurations
-- [packages/fuelhat](../packages/fuelhat/) Fuel Wallet scripts CLI
-- [packages/mediator](../packages/mediator/) Mediator is a PubSub library we use to better integrate XState machines and also other relevant event-driven issues.
+- [packages/app](@repository/packages/app/) Frontend Fuel Wallet application
+- [packages/config](@repository/packages/config/) Build configurations
+- [packages/fuelhat](@repository/packages/fuelhat/) Fuel Wallet scripts CLI
+- [packages/mediator](@repository/packages/mediator/) Mediator is a PubSub library we use to better integrate XState machines and also other relevant event-driven issues.
 
 ### Useful Scripts
 
-To make life easier we added as many useful scripts as possible to our [package.json](../package.json). These are some of the most used during development:
+To make life easier we added as many useful scripts as possible to our [package.json](@repository/package.json). These are some of the most used during development:
 
 ```sh
 pnpm <command name>
 ```
 
-| Script      | Description                                                             |
-| ----------- | ----------------------------------------------------------------------- |
-| `dev`       | Run development server for the WebApp [packages/app](../packages/app/). |
-| `storybook` | Run storybook, which is the place we use to develop our components.     |
-| `test`      | Run all units tests that are based on Jest.                             |
-| `test:e2e`  | Run all E2E tests that are based on Cypress.                            |
+| Script      | Description                                                                      |
+| ----------- | -------------------------------------------------------------------------------- |
+| `dev`       | Run development server for the WebApp [packages/app](@repository/packages/app/). |
+| `storybook` | Run storybook, which is the place we use to develop our components.              |
+| `test`      | Run all units tests that are based on Jest.                                      |
+| `test:e2e`  | Run all E2E tests that are based on Cypress.                                     |
 
-> Other scripts can be found in [package.json](../package.json).
+> Other scripts can be found in [package.json](@repository/package.json).
 
 ### Running Tests
 

--- a/packages/docs/docs/how-to-use.mdx
+++ b/packages/docs/docs/how-to-use.mdx
@@ -18,7 +18,7 @@ You can try this code directly in the developer console.
 
 First, you need to request a connection with the wallet, which will authorize your application to execute other actions. You can do this by accessing `fuel.connect()`.
 
-<CodeImport file="../examples/Connect.tsx" lineStart="15" lineEnd="16" />
+<CodeImport file="../examples/Connect.tsx" />
 
 The `connect()` method returns a promise. If you prefer to do it in an async way, you can use `fuel.on('connection', () => void)` to
 listen for changes in the connection.
@@ -29,7 +29,7 @@ listen for changes in the connection.
 
 Once the connection is authorized, you can list the user accounts using `window.fuel.accounts()`.
 
-<CodeImport file="../examples/ListAccounts.tsx" lineStart="18" lineEnd="19" />
+<CodeImport file="../examples/ListAccounts.tsx" />
 
 <Examples.ListAccounts />
 
@@ -37,7 +37,7 @@ Once the connection is authorized, you can list the user accounts using `window.
 
 You can also get the current account being used in the wallet using `window.fuel.currentAccount()`.
 
-<CodeImport file="../examples/CurrentAccount.tsx" lineStart="18" lineEnd="19" />
+<CodeImport file="../examples/CurrentAccount.tsx" />
 
 <Examples.CurrentAccount />
 
@@ -45,7 +45,7 @@ You can also get the current account being used in the wallet using `window.fuel
 
 With access to the user address and the connection authorized, you can request the user's signature using `fuel.signMessage`.
 
-<CodeImport file="../examples/SignMessage.tsx" lineStart="20" lineEnd="24" />
+<CodeImport file="../examples/SignMessage.tsx" />
 
 <Examples.SignMessage />
 
@@ -53,6 +53,6 @@ With access to the user address and the connection authorized, you can request t
 
 To transfer an amount to other address, use the `wallet.transfer` method and pass in the address you want to send to and the amount to send.
 
-<CodeImport file="../examples/Transfer.tsx" lineStart="36" lineEnd="41" />
+<CodeImport file="../examples/Transfer.tsx" />
 
 <Examples.Transfer />

--- a/packages/docs/examples/Connect.tsx
+++ b/packages/docs/examples/Connect.tsx
@@ -12,8 +12,10 @@ export function Connect() {
 
   const [handleConnect, isConnecting, errorConnect] = useLoading(async () => {
     console.debug('Request connection to Wallet!');
+    /* example:start */
     const isConnected = await fuel.connect();
     console.debug('Connection response', isConnected);
+    /* example:end */
     setConnected(isConnected);
   });
 

--- a/packages/docs/examples/CurrentAccount.tsx
+++ b/packages/docs/examples/CurrentAccount.tsx
@@ -15,8 +15,10 @@ export function CurrentAccount() {
   const [handleCurrentAccount, isLoadingCurrentAccount, errorCurrentAccount] =
     useLoading(async () => {
       console.debug('Request currentAccount to Wallet!');
+      /* example:start */
       const currentAccount = await fuel.currentAccount();
       console.debug('Current Account ', currentAccount);
+      /* example:end */
       setCurrentAccount(currentAccount);
     });
 

--- a/packages/docs/examples/ListAccounts.tsx
+++ b/packages/docs/examples/ListAccounts.tsx
@@ -15,8 +15,10 @@ export function ListAccounts() {
   const [handleGetAccounts, isLoadingAccounts, errorGetAccounts] = useLoading(
     async () => {
       console.debug('Request accounts to Wallet!');
+      /* example:start */
       const accounts = await fuel.accounts();
       console.debug('Accounts ', accounts);
+      /* example:end */
       setAccounts(accounts);
     }
   );

--- a/packages/docs/examples/SignMessage.tsx
+++ b/packages/docs/examples/SignMessage.tsx
@@ -17,11 +17,13 @@ export function SignMessage() {
   const [handleSignMessage, isSingingMessage, errorSigningMessage] = useLoading(
     async (message: string) => {
       console.debug('Request signature of message!');
+      /* example:start */
       const accounts = await fuel.accounts();
       const account = accounts[0];
       const wallet = await fuel.getWallet(account);
       const signedMessage = await wallet.signMessage(message);
       console.debug('Message signature', signedMessage);
+      /* example:end */
       setSignedMessage(signedMessage);
     }
   );

--- a/packages/docs/examples/Transfer.tsx
+++ b/packages/docs/examples/Transfer.tsx
@@ -33,12 +33,14 @@ export function Transfer() {
   const [sendTransaction, sendingTransaction, errorSendingTransaction] =
     useLoading(async (amount: BN) => {
       console.debug('Request signature transaction!');
+      /* example:start */
       const accounts = await fuel.accounts();
       const account = accounts[0];
       const wallet = await fuel.getWallet(account);
       const toAddress = Address.fromString(addr);
       const response = await wallet.transfer(toAddress, amount);
       console.debug('Transaction created!', response.id);
+      /* example:end */
       setProviderUrl(wallet.provider.url);
       setTxId(response.id);
     });

--- a/packages/docs/src/components/Link.tsx
+++ b/packages/docs/src/components/Link.tsx
@@ -1,6 +1,10 @@
 import type { LinkProps } from '@fuel-ui/react';
 import { Link as FuelLink } from '@fuel-ui/react';
 
+import { REPO_LINK } from '../constants';
+
 export function Link(props: LinkProps) {
-  return <FuelLink {...props} isExternal />;
+  const { href } = props;
+  const finalHref = href?.replace('@repository', REPO_LINK);
+  return <FuelLink {...props} href={finalHref} isExternal />;
 }

--- a/packages/docs/src/pages/index.tsx
+++ b/packages/docs/src/pages/index.tsx
@@ -1,15 +1,8 @@
-/* eslint-disable import/no-named-default */
-/* eslint-disable @typescript-eslint/no-explicit-any */
+import { useEffect } from 'react';
 
-import {
-  default as DocPage,
-  getStaticProps as docsGetStaticProps,
-} from './docs/[...slug]';
-
-export default function Home(props: any) {
-  return <DocPage {...props} />;
-}
-
-export async function getStaticProps() {
-  return docsGetStaticProps({ params: { slug: ['install'] } });
+export default function Home() {
+  useEffect(() => {
+    window.location.href = '/docs/install';
+  }, []);
+  return null;
 }


### PR DESCRIPTION
This PR;
- improves code example import migrating from lineStart and lineEnd to use comment blocks `/* example:start */` and
`/* example:end */`.
- Fix source code links. Currently, they are broken, pointing to the wrong link.
- Fix the footer navigator when entering on route `/` by changing to render to redirect to `/docs/install`.
- Fix repo links, now it's possible to use @repository on links that point to `https://github.com/FuelLabs/fuels-wallet/blob/master`

close: #537 