### PR TITLE
refactor: change `fuel.on` to accept string and externalize events on fuel instance

### DIFF
--- a/.changeset/tough-nails-compete.md
+++ b/.changeset/tough-nails-compete.md
@@ -1,0 +1,6 @@
+---
+'@fuel-wallet/types': patch
+'@fuel-wallet/sdk': patch
+---
+
+Move events enum to fuel object

--- a/packages/app/playwright/crx/crx.test.ts
+++ b/packages/app/playwright/crx/crx.test.ts
@@ -384,7 +384,7 @@ test.describe('FuelWallet Extension', () => {
 
       const onChangeAccountPromise = blankPage.evaluate(() => {
         return new Promise((resolve) => {
-          window.fuel.on('currentAccount', (account) => {
+          window.fuel.on(window.fuel.events.currentAccount, (account) => {
             resolve(account);
           });
         });

--- a/packages/docs/docs/api.mdx
+++ b/packages/docs/docs/api.mdx
@@ -98,11 +98,7 @@ The `on` method takes two arguments, the event name and a callback function. The
 
 This event is triggered when the connection status change between the Wallet and the application. The callback function receives the `connection` object.
 
-<CodeImport
-  file="../src/hooks/useIsConnected.tsx"
-  lineStart="10"
-  lineEnd="28"
-/>
+<CodeImport file="../src/hooks/useIsConnected.tsx" lineStart="9" lineEnd="27" />
 
 ### Accounts
 
@@ -110,7 +106,7 @@ This event is triggered when the list of connected accounts to the application c
 
 <CodeImport
   file="../examples/events/Accounts.tsx"
-  lineStart="24"
+  lineStart="23"
   lineEnd="33"
 />
 
@@ -122,7 +118,7 @@ This event is only triggered if the application has access to the current accoun
 
 <CodeImport
   file="../examples/events/CurrentAccount.tsx"
-  lineStart="24"
+  lineStart="23"
   lineEnd="35"
 />
 
@@ -130,4 +126,4 @@ This event is only triggered if the application has access to the current accoun
 
 This event is triggered when the client connects to a different network. The callback function receives the `network` object.
 
-<CodeImport file="../examples/events/Network.tsx" lineStart="28" lineEnd="38" />
+<CodeImport file="../examples/events/Network.tsx" lineStart="27" lineEnd="38" />

--- a/packages/docs/docs/how-to-use.mdx
+++ b/packages/docs/docs/how-to-use.mdx
@@ -76,11 +76,7 @@ The events enum `FuelWalletEvents` can be imported from the `@fuel-wallet/sdk` p
 
 To listen to connection events, you can use the `FuelWalletEvents.CONNECTION` event.
 
-<CodeImport
-  file="../src/hooks/useIsConnected.tsx"
-  lineStart="10"
-  lineEnd="28"
-/>
+<CodeImport file="../src/hooks/useIsConnected.tsx" lineStart="9" lineEnd="27" />
 <Examples.Events.Connection />
 
 ### Accounts
@@ -89,7 +85,7 @@ To listen to accounts events, you can use the `FuelWalletEvents.ACCOUNTS` event.
 
 <CodeImport
   file="../examples/events/Accounts.tsx"
-  lineStart="24"
+  lineStart="23"
   lineEnd="33"
 />
 <Examples.Events.Accounts />
@@ -100,7 +96,7 @@ To listen to current account events, you can use the `FuelWalletEvents.CURRENT_A
 
 <CodeImport
   file="../examples/events/CurrentAccount.tsx"
-  lineStart="24"
+  lineStart="23"
   lineEnd="35"
 />
 
@@ -110,7 +106,7 @@ To listen to current account events, you can use the `FuelWalletEvents.CURRENT_A
 
 To listen to network events, you can use the `FuelWalletEvents.NETWORK` event.
 
-<CodeImport file="../examples/events/Network.tsx" lineStart="28" lineEnd="38" />
+<CodeImport file="../examples/events/Network.tsx" lineStart="27" lineEnd="38" />
 
 Switch the network in your wallet to see the event triggered.
 

--- a/packages/docs/examples/events/Accounts.tsx
+++ b/packages/docs/examples/events/Accounts.tsx
@@ -1,6 +1,5 @@
 import { cssObj } from '@fuel-ui/css';
 import { Button, Stack, Tag, Text } from '@fuel-ui/react';
-import { FuelWalletEvents } from '@fuel-wallet/sdk';
 import { useEffect, useState } from 'react';
 
 import { ExampleBox } from '~/src/components/ExampleBox';
@@ -26,9 +25,9 @@ export function Accounts() {
   };
 
   useEffect(() => {
-    fuel?.on(FuelWalletEvents.ACCOUNTS, handleAccountsEvent);
+    fuel?.on(fuel.events.accounts, handleAccountsEvent);
     return () => {
-      fuel?.off(FuelWalletEvents.ACCOUNTS, handleAccountsEvent);
+      fuel?.off(fuel.events.accounts, handleAccountsEvent);
     };
   }, [fuel]);
 

--- a/packages/docs/examples/events/CurrentAccount.tsx
+++ b/packages/docs/examples/events/CurrentAccount.tsx
@@ -1,6 +1,5 @@
 import { cssObj } from '@fuel-ui/css';
 import { Button, Stack, Tag, Text } from '@fuel-ui/react';
-import { FuelWalletEvents } from '@fuel-wallet/sdk';
 import { useEffect, useState } from 'react';
 
 import { ExampleBox } from '~/src/components/ExampleBox';
@@ -27,10 +26,10 @@ export function CurrentAccount() {
 
   useEffect(() => {
     // listen to the current event account, and call the handleAccountEvent
-    fuel?.on(FuelWalletEvents.CURRENT_ACCOUNT, handleAccountEvent);
+    fuel?.on(fuel.events.currentAccount, handleAccountEvent);
     return () => {
       // remove the listener when the component is unmounted
-      fuel?.off(FuelWalletEvents.CURRENT_ACCOUNT, handleAccountEvent);
+      fuel?.off(fuel.events.currentAccount, handleAccountEvent);
     };
   }, [fuel]);
 

--- a/packages/docs/examples/events/Network.tsx
+++ b/packages/docs/examples/events/Network.tsx
@@ -1,6 +1,5 @@
 import { Flex, Text, Stack, Button } from '@fuel-ui/react';
 import type { FuelProviderConfig } from '@fuel-wallet/sdk';
-import { FuelWalletEvents } from '@fuel-wallet/sdk';
 import { useEffect, useState } from 'react';
 
 import { Code } from '~/src/components/Code';
@@ -30,10 +29,10 @@ export function NetworkExample() {
   };
 
   useEffect(() => {
-    fuel?.on(FuelWalletEvents.NETWORK, handleNetworkChange);
+    fuel?.on(fuel.events.network, handleNetworkChange);
 
     return () => {
-      fuel?.off(FuelWalletEvents.NETWORK, handleNetworkChange);
+      fuel?.off(fuel.events.network, handleNetworkChange);
     };
   }, [fuel]);
 

--- a/packages/docs/src/hooks/useIsConnected.tsx
+++ b/packages/docs/src/hooks/useIsConnected.tsx
@@ -1,4 +1,3 @@
-import { FuelWalletEvents } from '@fuel-wallet/sdk';
 import { useEffect, useState } from 'react';
 
 import { useFuel } from './useFuel';
@@ -21,9 +20,9 @@ export function useIsConnected() {
       main();
     }
 
-    fuel?.on(FuelWalletEvents.CONNECTION, main);
+    fuel?.on(fuel.events.connection, main);
     return () => {
-      fuel?.off(FuelWalletEvents.CONNECTION, main);
+      fuel?.off(fuel.events.connection, main);
     };
   }, [fuel]);
 

--- a/packages/sdk/src/Fuel.test.ts
+++ b/packages/sdk/src/Fuel.test.ts
@@ -1,4 +1,3 @@
-import { FuelWalletEvents } from '@fuel-wallet/types';
 import {
   Address,
   bn,
@@ -141,7 +140,7 @@ describe('Fuel Events', () => {
 
   test('Events: Connection events', async () => {
     const handleConnectionEvent = jest.fn();
-    fuel.on(FuelWalletEvents.CONNECTION, handleConnectionEvent);
+    fuel.on(fuel.events.connection, handleConnectionEvent);
     await fuel.connect();
     expect(handleConnectionEvent).toBeCalledWith(true);
     await fuel.disconnect();
@@ -150,21 +149,21 @@ describe('Fuel Events', () => {
 
   test('Events: Accounts events', async () => {
     const handleAccountsEvent = jest.fn();
-    fuel.on(FuelWalletEvents.ACCOUNTS, handleAccountsEvent);
+    fuel.on(fuel.events.accounts, handleAccountsEvent);
     const accounts = await fuel.accounts();
     expect(handleAccountsEvent).toBeCalledWith(accounts);
   });
 
   test('Events: CurrentAccount events', async () => {
     const handleCurrentAccountEvent = jest.fn();
-    fuel.on(FuelWalletEvents.CURRENT_ACCOUNT, handleCurrentAccountEvent);
+    fuel.on(fuel.events.currentAccount, handleCurrentAccountEvent);
     const currentAccount = await fuel.currentAccount();
     expect(handleCurrentAccountEvent).toBeCalledWith(currentAccount);
   });
 
   test('Events: Network events', async () => {
     const handleNetworkEvent = jest.fn();
-    fuel.on(FuelWalletEvents.NETWORK, handleNetworkEvent);
+    fuel.on(fuel.events.network, handleNetworkEvent);
     const network = await fuel.network();
     expect(handleNetworkEvent).toBeCalledWith(network);
   });

--- a/packages/sdk/src/Fuel.ts
+++ b/packages/sdk/src/Fuel.ts
@@ -27,6 +27,9 @@ export class Fuel extends FuelWalletConnection {
     },
   };
 
+  // Externalize events names
+  readonly events = FuelWalletEvents;
+
   async getProvider(): Promise<FuelWalletProvider> {
     // TODO: This solution should be improved by issue #506
     // by moving all connection throw events
@@ -42,7 +45,7 @@ export class Fuel extends FuelWalletConnection {
 
     // Listen for network changes and connect the provider
     // selected network from the user
-    this.on(FuelWalletEvents.NETWORK, async (network) => {
+    this.on(FuelWalletEvents.network, async (network) => {
       FuelWeb3Privates.provider?.connect(network.url);
     });
 

--- a/packages/sdk/src/FuelWalletConnection.ts
+++ b/packages/sdk/src/FuelWalletConnection.ts
@@ -1,13 +1,13 @@
-import type {
-  CommunicationMessage,
-  FuelEventArg,
-  FuelEvents,
-  FuelProviderConfig,
-} from '@fuel-wallet/types';
 import {
   CONTENT_SCRIPT_NAME,
   PAGE_SCRIPT_NAME,
   MessageTypes,
+} from '@fuel-wallet/types';
+import type {
+  CommunicationMessage,
+  FuelEventArg,
+  FuelProviderConfig,
+  FuelEvents,
 } from '@fuel-wallet/types';
 import type { TransactionRequestLike } from 'fuels';
 import type { JSONRPCRequest } from 'json-rpc-2.0';

--- a/packages/sdk/src/__mock__/Fuel.ts
+++ b/packages/sdk/src/__mock__/Fuel.ts
@@ -49,7 +49,7 @@ export class MockConnection extends BaseConnection {
     const network = {
       url: process.env.PUBLIC_PROVIDER_URL!,
     };
-    fuel.emit(FuelWalletEvents.NETWORK, network);
+    fuel.emit(FuelWalletEvents.network, network);
     return network;
   }
 
@@ -58,18 +58,18 @@ export class MockConnection extends BaseConnection {
   }
 
   async connect() {
-    fuel.emit(FuelWalletEvents.CONNECTION, true);
+    fuel.emit(FuelWalletEvents.connection, true);
     return true;
   }
 
   async disconnect() {
-    fuel.emit(FuelWalletEvents.CONNECTION, false);
+    fuel.emit(FuelWalletEvents.connection, false);
     return false;
   }
 
   async accounts() {
     const accounts = [userWallet.address.toAddress()];
-    fuel.emit(FuelWalletEvents.ACCOUNTS, accounts);
+    fuel.emit(FuelWalletEvents.accounts, accounts);
     return accounts;
   }
 
@@ -93,7 +93,7 @@ export class MockConnection extends BaseConnection {
 
   async currentAccount() {
     const account = userWallet.address.toAddress();
-    fuel.emit(FuelWalletEvents.CURRENT_ACCOUNT, account);
+    fuel.emit(FuelWalletEvents.currentAccount, account);
     return account;
   }
 }

--- a/packages/types/src/fuel.ts
+++ b/packages/types/src/fuel.ts
@@ -7,28 +7,28 @@ import type { JSONRPCRequest, JSONRPCResponse } from 'json-rpc-2.0';
 
 import type { Network } from './network';
 
-export enum FuelWalletEvents {
-  ACCOUNTS = 'accounts',
-  CURRENT_ACCOUNT = 'currentAccount',
-  CONNECTION = 'connection',
-  NETWORK = 'network',
-}
+export const FuelWalletEvents = {
+  accounts: 'accounts',
+  currentAccount: 'currentAccount',
+  connection: 'connection',
+  network: 'network',
+} as const;
 
 export type FuelEvents =
   | {
-      type: FuelWalletEvents.ACCOUNTS;
+      type: typeof FuelWalletEvents.accounts;
       data: Array<string>;
     }
   | {
-      type: FuelWalletEvents.CURRENT_ACCOUNT;
+      type: typeof FuelWalletEvents.currentAccount;
       data: string;
     }
   | {
-      type: FuelWalletEvents.CONNECTION;
+      type: typeof FuelWalletEvents.connection;
       data: boolean;
     }
   | {
-      type: FuelWalletEvents.NETWORK;
+      type: typeof FuelWalletEvents.network;
       data: Network;
     };
 


### PR DESCRIPTION
The implementation made on PR #526 has added events as an enum, but with this change, the user had to always import the Enum from the package in order to use it. The idea here is to externalize this enum directly on the fuel instance on the window.