### PR TITLE
feat: implement small improvements on the approve flow and tx approval

### DIFF
--- a/packages/app/playwright/crx/crx.test.ts
+++ b/packages/app/playwright/crx/crx.test.ts
@@ -357,6 +357,7 @@ test.describe('FuelWallet Extension', () => {
           approveTransactionPage,
           senderAccount.address.toString()
         );
+        await hasText(approveTransactionPage, 'Requesting a transaction from:');
         await getButtonByText(approveTransactionPage, /Approve/i).click();
 
         await expect(transferStatus).resolves.toBe('success');

--- a/packages/app/playwright/crx/crx.test.ts
+++ b/packages/app/playwright/crx/crx.test.ts
@@ -357,7 +357,7 @@ test.describe('FuelWallet Extension', () => {
           approveTransactionPage,
           senderAccount.address.toString()
         );
-        await hasText(approveTransactionPage, 'Requesting a transaction from:');
+        await hasText(approveTransactionPage, /Confirm before approve/i);
         await getButtonByText(approveTransactionPage, /Approve/i).click();
 
         await expect(transferStatus).resolves.toBe('success');

--- a/packages/app/src/systems/DApp/hooks/useTransactionRequest.tsx
+++ b/packages/app/src/systems/DApp/hooks/useTransactionRequest.tsx
@@ -57,6 +57,7 @@ const selectors = {
   originTitle: (state: TransactionRequestState) => state.context.input.title,
   favIconUrl: (state: TransactionRequestState) =>
     state.context.input.favIconUrl,
+  sendingTx: (state: TransactionRequestState) => state.matches('sendingTx'),
 };
 
 type UseTransactionRequestOpts = {
@@ -79,7 +80,9 @@ export function useTransactionRequest(opts: UseTransactionRequestOpts = {}) {
     },
     actions: {
       openDialog() {
-        store.openTransactionApprove();
+        if (!opts.isOriginRequired) {
+          store.openTransactionApprove();
+        }
       },
     },
   });
@@ -97,6 +100,7 @@ export function useTransactionRequest(opts: UseTransactionRequestOpts = {}) {
   const origin = useSelector(service, selectors.origin);
   const originTitle = useSelector(service, selectors.originTitle);
   const favIconUrl = useSelector(service, selectors.favIconUrl);
+  const isSendingTx = useSelector(service, selectors.sendingTx);
   const isLoading = status('loading');
   const showActions = !status('failed') && !status('success');
 
@@ -156,6 +160,7 @@ export function useTransactionRequest(opts: UseTransactionRequestOpts = {}) {
     title,
     tx,
     txStatus,
+    isSendingTx,
     handlers: {
       request,
       reset,

--- a/packages/app/src/systems/DApp/pages/TransactionRequest/TransactionRequest.tsx
+++ b/packages/app/src/systems/DApp/pages/TransactionRequest/TransactionRequest.tsx
@@ -10,23 +10,26 @@ import { TxContent, TxHeader } from '~/systems/Transaction';
 
 export function TransactionRequest() {
   const txRequest = useTransactionRequest({ isOriginRequired: true });
-  const { handlers, status, ...ctx } = txRequest;
+  const { handlers, status, isSendingTx, ...ctx } = txRequest;
   const { assets } = useAssets();
 
   if (!ctx.account) return null;
 
+  const shouldShowTx = status('waitingApproval') || isSendingTx;
+
   return (
     <>
-      <Layout title={ctx.title} isLoading={ctx.isLoading}>
+      <Layout title={ctx.title}>
         <Layout.TopBar type={TopBarType.external} />
         <Layout.Content css={styles.content}>
-          {ctx.isLoading && (
+          {ctx.isLoading && !txRequest.tx && (
             <TxContent.Loader header={<ConnectInfo.Loader />} />
           )}
-          {status('waitingApproval') && (
+          {shouldShowTx && (
             <TxContent.Info
               showDetails
               tx={txRequest.tx}
+              isLoading={status('loading')}
               header={
                 <>
                   <ConnectInfo

--- a/packages/app/src/systems/DApp/pages/TransactionRequest/TransactionRequest.tsx
+++ b/packages/app/src/systems/DApp/pages/TransactionRequest/TransactionRequest.tsx
@@ -97,7 +97,7 @@ export function TransactionRequest() {
               onPress={handlers.approve}
               isLoading={ctx.isLoading || status('sending')}
             >
-              Confirm
+              Approve
             </Button>
           </Layout.BottomBar>
         )}

--- a/packages/app/src/systems/Transaction/components/TxContent/TxContent.tsx
+++ b/packages/app/src/systems/Transaction/components/TxContent/TxContent.tsx
@@ -31,6 +31,7 @@ type TxContentInfoProps = {
   txStatus?: Maybe<TxStatus>;
   showDetails?: boolean;
   assets?: Maybe<Asset[]>;
+  isLoading?: boolean;
 };
 
 function TxContentInfo({
@@ -40,6 +41,7 @@ function TxContentInfo({
   footer,
   showDetails,
   assets,
+  isLoading,
 }: TxContentInfoProps) {
   const status = tx?.status || txStatus;
   return (
@@ -49,6 +51,7 @@ function TxContentInfo({
         operations={tx?.operations}
         status={status}
         assets={assets}
+        isLoading={isLoading}
       />
       {showDetails && <TxDetails fee={tx?.fee} />}
       {footer}

--- a/packages/app/src/systems/Transaction/components/TxFromTo/TxFromTo.test.tsx
+++ b/packages/app/src/systems/Transaction/components/TxFromTo/TxFromTo.test.tsx
@@ -24,12 +24,21 @@ describe('TxFromTo', () => {
     expect(() => screen.getByLabelText('Loading Spinner')).toThrow();
   });
 
-  it('should not show any address info and show spinner when isLoading is true', async () => {
-    render(<TxFromTo {...PROPS} isLoading />);
+  it('should show spinner and loaders when isLoading is true and from and to are empty', async () => {
+    render(<TxFromTo isLoading />);
     expect(() => screen.getByText('From')).toThrow();
     expect(() => screen.getByText('fuel1g...kuj7')).toThrow();
     expect(() => screen.getByText('To (Contract)')).toThrow();
     expect(() => screen.getByText('fuel1y...y6wk')).toThrow();
+    expect(screen.getByLabelText('Loading Spinner')).toBeInTheDocument();
+  });
+
+  it('should show info and spinner when isLoading is true and from and to exits', async () => {
+    render(<TxFromTo {...PROPS} isLoading />);
+    expect(screen.getByText('From')).toBeInTheDocument();
+    expect(screen.getByText('fuel1g...kuj7')).toBeInTheDocument();
+    expect(screen.getByText('To (Contract)')).toBeInTheDocument();
+    expect(screen.getByText('fuel1y...y6wk')).toBeInTheDocument();
     expect(screen.getByLabelText('Loading Spinner')).toBeInTheDocument();
   });
 

--- a/packages/app/src/systems/Transaction/components/TxFromTo/TxFromTo.tsx
+++ b/packages/app/src/systems/Transaction/components/TxFromTo/TxFromTo.tsx
@@ -69,12 +69,12 @@ export function TxFromTo({
         isLoading={isLoading}
         operationName={operationName}
       />
-      {isLoading ? (
+      {isLoading && !from ? (
         <TxRecipientCard.Loader />
       ) : (
         <TxRecipientCard recipient={from} />
       )}
-      {isLoading ? (
+      {isLoading && !to ? (
         <TxRecipientCard.Loader />
       ) : (
         <TxRecipientCard recipient={to} isReceiver />

--- a/packages/app/src/systems/Transaction/components/TxOperation/TxOperation.tsx
+++ b/packages/app/src/systems/Transaction/components/TxOperation/TxOperation.tsx
@@ -12,9 +12,15 @@ export type TxOperationProps = {
   operation?: Operation;
   status?: Maybe<TxStatus>;
   assets?: Maybe<Asset[]>;
+  isLoading?: boolean;
 };
 
-export function TxOperation({ operation, status, assets }: TxOperationProps) {
+export function TxOperation({
+  operation,
+  status,
+  assets,
+  isLoading,
+}: TxOperationProps) {
   const { from, to, assetsSent } = operation ?? {};
   const amounts = assetsSent?.map((assetSent) => {
     const asset = assets?.find((a) => a.assetId === assetSent.assetId);
@@ -29,6 +35,7 @@ export function TxOperation({ operation, status, assets }: TxOperationProps) {
         from={from}
         to={to}
         status={status}
+        isLoading={isLoading}
         operationName={operation?.name}
       />
       {!!amounts?.length && <AssetsAmount amounts={amounts} />}

--- a/packages/app/src/systems/Transaction/components/TxOperations/TxOperations.tsx
+++ b/packages/app/src/systems/Transaction/components/TxOperations/TxOperations.tsx
@@ -11,12 +11,14 @@ export type TxOperationsProps = {
   operations?: Operation[];
   status?: Maybe<TxStatus>;
   assets?: Maybe<Asset[]>;
+  isLoading?: boolean;
 };
 
 export function TxOperations({
   operations,
   status,
   assets,
+  isLoading,
 }: TxOperationsProps) {
   return (
     <Flex css={styles.root}>
@@ -26,6 +28,7 @@ export function TxOperations({
           operation={operation}
           status={status}
           assets={assets}
+          isLoading={isLoading}
         />
       ))}
     </Flex>


### PR DESCRIPTION
This PR;
- Fix approval TX request by ignoring the tx popup on external requests;
- improve after approval screen to show just a loader instead of putting the entire state at a loading;
- Add a test to ensure tx approval from DApp opens the correct screen.