### PR TITLE
fix: auto lock wallet

### DIFF
--- a/.changeset/forty-cycles-share.md
+++ b/.changeset/forty-cycles-share.md
@@ -1,0 +1,5 @@
+---
+'fuels-wallet': patch
+---
+
+Fix Wallet auto locker.

--- a/packages/app/manifest.config.ts
+++ b/packages/app/manifest.config.ts
@@ -36,5 +36,5 @@ export default defineManifest({
     },
   ],
   host_permissions: ['<all_urls>'],
-  permissions: ['alarms', 'tabs', 'clipboardWrite', 'scripting'],
+  permissions: ['storage', 'alarms', 'tabs', 'clipboardWrite', 'scripting'],
 });

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -30,3 +30,5 @@ export const IS_DEVELOPMENT = process.env.NODE_ENV !== 'production';
 export const IS_TEST = process.env.NODE_ENV === 'test';
 export const IS_CRX_POPUP =
   IS_CRX && globalThis.location.pathname === CRXPages.popup;
+/** Time in minutes before Wallet auto locks */
+export const AUTO_LOCK_IN_MINUTES = 20;

--- a/packages/app/src/systems/CRX/background/services/VaultService.ts
+++ b/packages/app/src/systems/CRX/background/services/VaultService.ts
@@ -4,30 +4,53 @@ import {
   VAULT_SCRIPT_NAME,
 } from '@fuel-wallet/types';
 
+import { saveSecret, loadSecret, getTimer, clearSession } from '../../utils';
+
 import type { CommunicationProtocol } from './CommunicationProtocol';
 
+import { AUTO_LOCK_IN_MINUTES } from '~/config';
 import { VaultServer } from '~/systems/Vault/services/VaultServer';
 
-export class VaultService {
-  readonly vault: VaultServer;
+export class VaultService extends VaultServer {
   readonly communicationProtocol: CommunicationProtocol;
 
   constructor(communicationProtocol: CommunicationProtocol) {
+    super();
     this.communicationProtocol = communicationProtocol;
-    this.vault = new VaultServer();
+    this.autoLock();
+    this.autoUnlock();
     this.setupListeners();
-    this.setupAutoClose();
   }
 
-  async setupAutoClose() {
-    this.vault.manager.on('unlock', () => {
-      chrome.alarms.create('VaultAutoClose', { delayInMinutes: 15 });
-      chrome.alarms.onAlarm.addListener((event) => {
-        if (event.name === 'VaultAutoClose') {
-          this.vault.manager.lock();
-        }
-      });
-    });
+  async unlock({ password }: { password: string }): Promise<void> {
+    await super.unlock({ password });
+    saveSecret(password, AUTO_LOCK_IN_MINUTES);
+  }
+
+  async lock(): Promise<void> {
+    await super.lock();
+    this.emitLockEvent();
+  }
+
+  async autoLock() {
+    // Check every second if the timer has expired
+    // If so, clear the secret and lock the vault
+    setInterval(async () => {
+      const timer = await getTimer();
+      if (timer === 0) return;
+      if (timer < Date.now()) {
+        clearSession();
+        this.lock();
+      }
+    }, 1000);
+  }
+
+  async autoUnlock() {
+    const secret = await loadSecret();
+    if (secret) {
+      // Unlock vault directly without saving a new timestamp
+      await super.unlock({ password: secret });
+    }
   }
 
   static start(communicationProtocol: CommunicationProtocol) {
@@ -39,7 +62,7 @@ export class VaultService {
       if (!event.sender?.origin?.includes(chrome.runtime.id)) return;
       if (event.sender?.id !== chrome.runtime.id) return;
       if (event.target !== VAULT_SCRIPT_NAME) return;
-      const response = await this.vault.server.receive(event.request);
+      const response = await this.server.receive(event.request);
       if (response) {
         this.communicationProtocol.postMessage({
           id: event.id,
@@ -48,6 +71,24 @@ export class VaultService {
           response,
         });
       }
+    });
+  }
+
+  emitLockEvent() {
+    // Get all current Wallet PopUp instances to emit the lock event
+    const origins = Array.from(this.communicationProtocol.ports.values())
+      .filter((p) => p.sender?.id === chrome.runtime.id)
+      .map((p) => p.sender?.origin) as Array<string>;
+    // Broadcast the lock event
+    this.communicationProtocol.broadcast(origins, {
+      type: MessageTypes.event,
+      target: POPUP_SCRIPT_NAME,
+      events: [
+        {
+          event: 'lock',
+          params: [],
+        },
+      ],
     });
   }
 }

--- a/packages/app/src/systems/CRX/utils/index.ts
+++ b/packages/app/src/systems/CRX/utils/index.ts
@@ -2,3 +2,4 @@ export * from './popups';
 export * from './tabs';
 export * from './position';
 export * from './utils';
+export * from './secret';

--- a/packages/app/src/systems/CRX/utils/secret.ts
+++ b/packages/app/src/systems/CRX/utils/secret.ts
@@ -1,0 +1,58 @@
+import dayjs from 'dayjs';
+import { decrypt, encrypt } from 'fuels';
+
+const SALT_KEY = 'salt';
+
+async function createSalt() {
+  const salt = crypto.randomUUID();
+  await chrome.storage.local.set({ salt });
+  return salt;
+}
+
+async function getSalt(): Promise<string> {
+  const data = await chrome.storage.local.get(SALT_KEY);
+  return data.salt;
+}
+
+export async function clearSession() {
+  chrome.storage.local.remove('salt');
+  chrome.storage.session.clear();
+}
+
+export async function getTimer(): Promise<number> {
+  const { timer } = await chrome.storage.session.get('timer');
+  return timer || 0;
+}
+
+export async function saveSecret(secret: string, autoLockInMinutes: number) {
+  const salt = await createSalt();
+  try {
+    const encrypted = await encrypt(salt, secret);
+    chrome.storage.session.set({
+      data: encrypted,
+      timer: dayjs().add(autoLockInMinutes, 'minute').valueOf(),
+    });
+  } catch {
+    clearSession();
+  }
+}
+
+export async function loadSecret() {
+  const salt = await getSalt();
+  const { data: encrypted, timer } = await chrome.storage.session.get([
+    'data',
+    'timer',
+  ]);
+
+  if (salt && timer > Date.now()) {
+    try {
+      const secret = await decrypt<string>(salt, encrypted);
+      return secret;
+    } catch {
+      // ignore error
+    }
+  }
+
+  clearSession();
+  return null;
+}

--- a/packages/app/src/systems/Unlock/events.ts
+++ b/packages/app/src/systems/Unlock/events.ts
@@ -3,6 +3,9 @@ import { Services } from '~/store';
 
 export function unlockEvents(store: Store) {
   return {
+    checkLock() {
+      store.send(Services.unlock, { type: 'CHECK_LOCK' });
+    },
     lock() {
       store.send(Services.unlock, { type: 'LOCK_WALLET' });
     },

--- a/packages/app/src/systems/Unlock/hooks/useUnlock.tsx
+++ b/packages/app/src/systems/Unlock/hooks/useUnlock.tsx
@@ -1,6 +1,9 @@
+import { useEffect } from 'react';
+
 import type { UnlockMachineState } from '../machines';
 
 import { store, Services } from '~/store';
+import { VaultService } from '~/systems/Vault';
 
 const selectors = {
   error(state: UnlockMachineState) {
@@ -22,6 +25,17 @@ export function useUnlock() {
   const isLoading = store.useSelector(Services.unlock, selectors.isLoading);
   const isUnlocked = store.useSelector(Services.unlock, selectors.isUnlocked);
   const isReseting = store.useSelector(Services.unlock, selectors.isReseting);
+
+  // Lock Wallet when Vault is locked
+  useEffect(() => {
+    const onLock = () => {
+      store.checkLock();
+    };
+    VaultService.on('lock', onLock);
+    return () => {
+      VaultService.off('lock', onLock);
+    };
+  }, []);
 
   store.useUpdateMachineConfig(Services.unlock, {
     actions: {

--- a/packages/app/src/systems/Unlock/machines/unlockMachine.tsx
+++ b/packages/app/src/systems/Unlock/machines/unlockMachine.tsx
@@ -33,6 +33,9 @@ export type UnlockWalletEvent =
     }
   | {
       type: 'RESET_WALLET';
+    }
+  | {
+      type: 'CHECK_LOCK';
     };
 
 export type UnlockMachineEvents = UnlockWalletEvent;
@@ -124,6 +127,9 @@ export const unlockMachine = createMachine(
     on: {
       LOCK_WALLET: {
         target: 'locking',
+      },
+      CHECK_LOCK: {
+        target: 'checkingLocked',
       },
     },
   },

--- a/packages/app/src/systems/Vault/connectors/VaultCRXConnector.ts
+++ b/packages/app/src/systems/Vault/connectors/VaultCRXConnector.ts
@@ -2,6 +2,7 @@ import type {
   RequestMessage,
   ResponseMessage,
   CommunicationMessage,
+  EventMessage,
 } from '@fuel-wallet/types';
 import {
   POPUP_SCRIPT_NAME,
@@ -31,9 +32,18 @@ export class VaultCRXConnector {
       case MessageTypes.response:
         this.onResponse(message);
         break;
+      case MessageTypes.event:
+        this.onEvent(message);
+        break;
       default:
     }
   };
+
+  async onEvent(message: EventMessage) {
+    message.events.forEach((event) => {
+      this.clientVault.emit(event.event, ...event.params);
+    });
+  }
 
   async onResponse(message: ResponseMessage) {
     this.clientVault.client.receive(message.response);

--- a/packages/app/src/systems/Vault/services/VaultClient.ts
+++ b/packages/app/src/systems/Vault/services/VaultClient.ts
@@ -1,3 +1,4 @@
+import EventEmitter from 'events';
 import type { JSONRPCParams, JSONRPCRequest } from 'json-rpc-2.0';
 import { JSONRPCClient } from 'json-rpc-2.0';
 
@@ -7,10 +8,11 @@ import { VaultServer } from './VaultServer';
 
 import { IS_CRX } from '~/config';
 
-export class VaultClient {
+export class VaultClient extends EventEmitter {
   readonly client: JSONRPCClient;
 
   constructor() {
+    super();
     // Setup client JSONRPC
     this.client = new JSONRPCClient(async (request) => {
       this.onRequest(request);


### PR DESCRIPTION
Currently the Vault Manager rely only on memory data for keep the Wallet unlock. Because of the life cycle of the Service Workers on CRX. Keeping memory just on a variable is not possible across executions. That was causing the Wallet to auto lock before the 15minutes window.

For solving this problem, I have move to a approach where a secret that enable us to unlock the vault is stored inside the Storage Memory provided by the browser for sharing sensitive data, across S.Workers without saving this data on disk and with browser native access control.

On this issue I have also implemented a event for auto lock current sessions when the vault is locked, avoiding users to be stuck on the middle of a Flow.

close: #712 