### PR TITLE
fix: edit account refresh account list

### DIFF
--- a/.changeset/angry-mayflies-taste.md
+++ b/.changeset/angry-mayflies-taste.md
@@ -1,0 +1,5 @@
+---
+'fuels-wallet': minor
+---
+
+Fixed edit account not updating the account list

--- a/packages/app/src/systems/Account/machines/accountsMachine.tsx
+++ b/packages/app/src/systems/Account/machines/accountsMachine.tsx
@@ -80,12 +80,6 @@ export const accountsMachine = createMachine(
           SET_CURRENT_ACCOUNT: {
             target: 'settingCurrentAccount',
           },
-          REFRESH_ACCOUNTS: {
-            target: 'fetchingAccounts',
-          },
-          REFRESH_ACCOUNT: {
-            target: 'refreshAccount',
-          },
           TOGGLE_HIDE_ACCOUNT: {
             actions: ['toggleHideAccount', 'notifyUpdateAccounts'],
             target: 'idle',
@@ -179,6 +173,12 @@ export const accountsMachine = createMachine(
     on: {
       LOGOUT: {
         target: 'loggingout',
+      },
+      REFRESH_ACCOUNTS: {
+        target: 'fetchingAccounts',
+      },
+      REFRESH_ACCOUNT: {
+        target: 'refreshAccount',
       },
     },
   },


### PR DESCRIPTION
[FRO-111](https://linear.app/fuel-network/issue/FRO-111/after-editing-a-account-the-account-list-should-be-refetch)