### PR TITLE
feat: index all pages on docsearch

### DIFF
--- a/packages/docs/docsearch.json
+++ b/packages/docs/docsearch.json
@@ -1,6 +1,12 @@
 {
   "index_name": "fuel_wallet_docs",
-  "start_urls": ["https://wallet.fuel.network/"],
+  "start_urls": [
+    "https://wallet.fuel.network/docs/install/",
+    "https://wallet.fuel.network/docs/how-to-use/",
+    "https://wallet.fuel.network/docs/dev/getting-started/",
+    "https://wallet.fuel.network/docs/contributing/running-locally/",
+    "https://wallet.fuel.network/docs/browser-support/"
+  ],
   "selectors": {
     "lvl0": "h1",
     "lvl1": "h2",

--- a/packages/docs/docsearch.json
+++ b/packages/docs/docsearch.json
@@ -1,11 +1,15 @@
 {
   "index_name": "fuel_wallet_docs",
   "start_urls": [
+    "https://wallet.fuel.network/docs/browser-support/",
     "https://wallet.fuel.network/docs/install/",
     "https://wallet.fuel.network/docs/how-to-use/",
     "https://wallet.fuel.network/docs/dev/getting-started/",
+    "https://wallet.fuel.network/docs/dev/reference/",
+    "https://wallet.fuel.network/docs/dev/react/",
     "https://wallet.fuel.network/docs/contributing/running-locally/",
-    "https://wallet.fuel.network/docs/browser-support/"
+    "https://wallet.fuel.network/docs/contributing/guide/",
+    "https://wallet.fuel.network/docs/contributing/linking-deps/"
   ],
   "selectors": {
     "lvl0": "h1",


### PR DESCRIPTION
Add all links for docsearch to index, the current approach was not indexing all pages as docsearch was not able to detect all paths related to `/`.