### PR TITLE
fix: export default last

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -13,8 +13,8 @@
     "exports": {
       ".": {
         "require": "./dist/index.js",
-        "default": "./dist/index.mjs",
-        "types": "./dist/index.d.ts"
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.mjs"
       }
     }
   },


### PR DESCRIPTION
Fixes "Module not found: Default condition should be last one" error.