### PR TITLE
docs: Fixing typo and indication (Developer switch is on the top right)

### DIFF
--- a/packages/docs/docs/install.mdx
+++ b/packages/docs/docs/install.mdx
@@ -19,10 +19,10 @@ Watch the video below for step-by-step instructions.
 - Open the extensions page; it can be done by:
   - Clicking on settings -> extensions or;
   - Accessing `brave://extensions/` or `chrome://extensions/`.
-- Enable the "Developer mode" switch on the top left
+- Enable the "Developer mode" switch on the top right
 - Load `fuel-wallet.zip` by:
   - Dragging your downloaded Fuel wallet file and dropping it in the extensions page or;
-  - Clicking on `Load unpacked` and select the file.
+  - Clicking on `Load unpacked` and selecting the file.
 - If all goes right, an onboarding page will instantly open.
 
 The Fuel Wallet extension is now ready to use.


### PR DESCRIPTION
Simple update to the documentation