### PR TITLE
fix: default connector Fuel Wallet

### DIFF
--- a/.changeset/lazy-dingos-relate.md
+++ b/.changeset/lazy-dingos-relate.md
@@ -1,0 +1,5 @@
+---
+'@fuel-wallet/sdk': minor
+---
+
+fix: default connector Fuel Wallet

--- a/packages/sdk/src/connections/WindowConnection.ts
+++ b/packages/sdk/src/connections/WindowConnection.ts
@@ -40,7 +40,7 @@ export class WindowConnection extends BaseConnection {
 
   addConnector(connector: FuelWalletConnector): void {
     // Ensure Fuel Wallet is the default connector
-    if (this.connectorName === 'Fuel Wallet') {
+    if (connector.name === 'Fuel Wallet') {
       this.connectorName = connector.name;
     }
     if (this.hasConnector(connector.name)) {

--- a/packages/sdk/src/tests/FuelWalletConnectors.test.ts
+++ b/packages/sdk/src/tests/FuelWalletConnectors.test.ts
@@ -32,6 +32,10 @@ describe('Fuel Connectors', () => {
     expect(fuel.hasConnector('Third Wallet')).toBeTruthy();
   });
 
+  test('Fuel Wallet should be the default connector', async () => {
+    expect(fuel.connectorName).toEqual('Fuel Wallet');
+  });
+
   test('selectConnector', async () => {
     expect(await fuel.selectConnector('Fuel Wallet')).toBeTruthy();
     expect(await fuel.selectConnector('Third Wallet')).toBeTruthy();


### PR DESCRIPTION
Fix to the default Fuel Wallet connector functionality. When adding a connector we need to check the name of this connector instead of the currently selected connector

close #805