### PR TITLE
fix: Asset Screen to allow empty img url

### DIFF
--- a/.changeset/five-schools-turn.md
+++ b/.changeset/five-schools-turn.md
@@ -1,0 +1,5 @@
+---
+'fuels-wallet': patch
+---
+
+Fix validation on Asset Screen to allow empty image url field

--- a/packages/app/src/systems/Asset/hooks/useAssetForm.tsx
+++ b/packages/app/src/systems/Asset/hooks/useAssetForm.tsx
@@ -20,6 +20,7 @@ function isValidId(id: any) {
 }
 
 function isValidUrl(url: any) {
+  if (url === '') return true;
   try {
     // eslint-disable-next-line no-new
     new URL(url);


### PR DESCRIPTION
close: https://linear.app/fuel-network/issue/FRO-239