### PR TITLE
chore: put test as last params in node commands

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -25,7 +25,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Start Test Node
-        run: pnpm node:test:up
+        run: pnpm node:up:test
 
       - name: Graphql Codegen
         run: pnpm codegen:app
@@ -59,7 +59,7 @@ jobs:
           base-coverage-file: ${{ env.COVERAGE_FILE }}
 
       - name: Stop Test Node
-        run: pnpm node:test:clean
+        run: pnpm node:clean:test
 
   tests-e2e:
     name: E2E Tests
@@ -73,7 +73,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Start Test Node
-        run: pnpm node:test:up
+        run: pnpm node:up:test
 
       - name: Graphql Codegen
         run: pnpm codegen:app
@@ -102,4 +102,4 @@ jobs:
           retention-days: 30
 
       - name: Stop Test Node
-        run: pnpm node:test:clean
+        run: pnpm node:clean:test

--- a/package.json
+++ b/package.json
@@ -123,8 +123,7 @@
       "vite@<2.9.16": ">=2.9.16",
       "semver@<7.5.2": ">=7.5.2",
       "node-fetch@<2.6.7": ">=2.6.7",
-      "word-wrap": "npm:@aashutoshrathi/word-wrap",
-      "cross-fetch": "4.0.0"
+      "word-wrap": "npm:@aashutoshrathi/word-wrap"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -44,11 +44,11 @@
     "lint:check": "eslint . --ext .ts,.tsx,.js,.jsx",
     "lint:fix": "pnpm lint:check --fix",
     "node:up": "make -C ./docker up",
-    "node:test:up": "make -C ./docker up-test",
+    "node:up:test": "make -C ./docker up-test",
     "node:down": "make -C ./docker down",
-    "node:test:down": "make -C ./docker down-test",
+    "node:down:test": "make -C ./docker down-test",
     "node:clean": "make -C ./docker clean",
-    "node:test:clean": "make -C ./docker clean-test",
+    "node:clean:test": "make -C ./docker clean-test",
     "nodes:up": "run-s node:up node:test:up",
     "nodes:down": "run-s node:down node:test:down",
     "nodes:clean": "run-s node:clean node:test:clean",
@@ -123,7 +123,8 @@
       "vite@<2.9.16": ">=2.9.16",
       "semver@<7.5.2": ">=7.5.2",
       "node-fetch@<2.6.7": ">=2.6.7",
-      "word-wrap": "npm:@aashutoshrathi/word-wrap"
+      "word-wrap": "npm:@aashutoshrathi/word-wrap",
+      "cross-fetch": "4.0.0"
     }
   }
 }

--- a/packages/docs/docs/contributing/running-locally.mdx
+++ b/packages/docs/docs/contributing/running-locally.mdx
@@ -101,7 +101,7 @@ All tests are run against the local node configured in the files `packages/app/.
 Before running test, make sure a local test node is running:
 
 ```sh
-pnpm node:test:up
+pnpm node:up:test
 ```
 
 Then, to run tests use:
@@ -131,7 +131,7 @@ pnpm test:e2e
 #### Run Tests E2E in CI/TEST env Mode
 
 ```sh
-pnpm node:test:up
+pnpm node:up:test
 ```
 
 ```sh


### PR DESCRIPTION
currently our node commands are like:

normal node command `pnpm node:up` 

test node command `pnpm node:test:up`


I'm just changing the order and putting `test` as last param: `pnpm node:up:test` 

the reason is that "test" works like a modifier, almost a tag: `pnpm node --test` ...
if you're used to run `pnpm node:up` , the natural way for running the test command will be just adding the modifier at the end: `pnpm node:up:test`