### PR TITLE
fix: sdk connectors syncing

### DIFF
--- a/.changeset/giant-pears-doubt.md
+++ b/.changeset/giant-pears-doubt.md
@@ -1,0 +1,5 @@
+---
+'@fuel-wallet/sdk': patch
+---
+
+Fix connectors syncing on Fuel SDK standalone use

--- a/packages/docs/examples/Connectors.tsx
+++ b/packages/docs/examples/Connectors.tsx
@@ -44,7 +44,8 @@ export function Connectors() {
     setConnectors(connectors);
 
     const onConnectors = () => {
-      setConnectors(fuel.listConnectors());
+      console.log('Connectors changed!', fuel.listConnectors());
+      setConnectors(Array.from(fuel.listConnectors()));
     };
 
     /* eventConnectors:start */

--- a/packages/docs/examples/Connectors.tsx
+++ b/packages/docs/examples/Connectors.tsx
@@ -44,7 +44,6 @@ export function Connectors() {
     setConnectors(connectors);
 
     const onConnectors = () => {
-      console.log('Connectors changed!', fuel.listConnectors());
       setConnectors(Array.from(fuel.listConnectors()));
     };
 

--- a/packages/docs/src/hooks/useFuel.tsx
+++ b/packages/docs/src/hooks/useFuel.tsx
@@ -1,17 +1,18 @@
 import { Fuel } from '@fuel-wallet/sdk';
 import { useState, useEffect } from 'react';
 
+const fuelSDK = new Fuel({ name: 'Fuel Wallet' });
+
 export function useFuel() {
   const [error, setError] = useState('');
   const [isLoading, setLoading] = useState(true);
-  const [fuel] = useState<Fuel>(new Fuel({ name: 'Fuel Wallet' }));
 
   useEffect(() => {
-    fuel.hasWallet().then((hasWallet) => {
+    fuelSDK.hasWallet().then((hasWallet) => {
       setError(hasWallet ? '' : 'fuel not detected on the window!');
       setLoading(false);
     });
   }, []);
 
-  return [fuel as Fuel, error, isLoading] as const;
+  return [fuelSDK, error, isLoading] as const;
 }

--- a/packages/sdk/src/connections/WindowConnection.ts
+++ b/packages/sdk/src/connections/WindowConnection.ts
@@ -129,6 +129,28 @@ export class WindowConnection extends BaseConnection {
     window.postMessage(message, origin || window.origin);
   }
 
+  bindFuelConnectors(fuel: Window['fuel']) {
+    // Prevent binding to self if this happen the
+    // object would enter on a infinite loop
+    const isSelf = (fuel as WindowConnection) === this;
+    if (!fuel || isSelf) return;
+    // Bind to fuel events to
+    // sync with current instace
+    fuel.on('connectors', (connectors) => {
+      this.connectors = connectors;
+      this.emit('connectors', connectors);
+    });
+    fuel.on('currentConnector', (connector) => {
+      this.selectConnector(connector.name);
+    });
+    // Update the current connectors list
+    this.connectors = fuel.listConnectors();
+    // Trigger connectros list changed event
+    this.emit('connectors', this.listConnectors());
+    // Sync the current connector
+    this.selectConnector(fuel.connectorName);
+  }
+
   handleFuelInjected() {
     // Timeout after 10 retries i.e., 1 second
     if (this._retry === 9) {
@@ -149,7 +171,9 @@ export class WindowConnection extends BaseConnection {
         this.isListenerAdded = true;
       }
       if (window.fuel) {
+        clearInterval(this._injectionTimeout);
         this._hasWallet.resolve(true);
+        this.bindFuelConnectors(window.fuel);
 
         // Execute pending requests in the queue
         let request = this.queue.shift();
@@ -157,7 +181,6 @@ export class WindowConnection extends BaseConnection {
           this.sendRequest(request);
           request = this.queue.shift();
         }
-        clearInterval(this._injectionTimeout);
       }
     }
   }

--- a/packages/sdk/src/connections/WindowConnection.ts
+++ b/packages/sdk/src/connections/WindowConnection.ts
@@ -132,7 +132,8 @@ export class WindowConnection extends BaseConnection {
   bindFuelConnectors(fuel: Window['fuel']) {
     // Prevent binding to self if this happen the
     // object would enter on a infinite loop
-    const isSelf = (fuel as WindowConnection) === this;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const isSelf = (fuel as any) === this;
     if (!fuel || isSelf) return;
     // Bind to fuel events to
     // sync with current instace

--- a/packages/sdk/src/tests/FuelWalletConnectors.test.ts
+++ b/packages/sdk/src/tests/FuelWalletConnectors.test.ts
@@ -1,4 +1,4 @@
-import type { Fuel } from '../Fuel';
+import { Fuel } from '../Fuel';
 
 import type { MockServices } from './__mock__';
 import { mockFuel } from './__mock__';
@@ -7,8 +7,10 @@ describe('Fuel Connectors', () => {
   let mocksConnector1: MockServices;
   let mocksConnector2: MockServices;
   let fuel: Fuel;
+  let fuelSDK: Fuel;
 
   beforeAll(() => {
+    fuelSDK = new Fuel({ name: 'Fuel Wallet' });
     mocksConnector1 = mockFuel();
     mocksConnector2 = mockFuel({ name: 'Third Wallet' });
     fuel = window.fuel!;
@@ -19,12 +21,14 @@ describe('Fuel Connectors', () => {
     mocksConnector2.destroy();
   });
 
-  test('listConnectors', () => {
+  test('listConnectors', async () => {
     const connectors = fuel.listConnectors();
-    expect(connectors.map((c) => c.name)).toEqual([
-      'Fuel Wallet',
-      'Third Wallet',
-    ]);
+    await fuelSDK.hasWallet();
+    const connectorsSDK = fuelSDK.listConnectors();
+    const expectedConnectors = ['Fuel Wallet', 'Third Wallet'];
+
+    expect(connectors.map((c) => c.name)).toEqual(expectedConnectors);
+    expect(connectorsSDK.map((c) => c.name)).toEqual(expectedConnectors);
   });
 
   test('hasConnector', () => {


### PR DESCRIPTION
Currently, when using the SDK directly instead of window. Fuel, the connectors are not updated once they are available. This fix creates a syncing handler to ensure data is bonded between both. This will probably improve the communication protocol refactor. https://github.com/FuelLabs/fuels-wallet/issues/506