### PR TITLE
fix: make useFuel return undefined when window is loading

### DIFF
--- a/packages/react/src/components/FuelProvider.tsx
+++ b/packages/react/src/components/FuelProvider.tsx
@@ -33,8 +33,8 @@ export const FuelReactContext = createContext<FuelReactContextType | null>(
   null
 );
 
-export const useFuel = () => {
-  return useContext(FuelReactContext) as FuelReactContextType;
+export const useFuel = (): FuelReactContextType => {
+  return useContext(FuelReactContext) ?? { fuel: undefined };
 };
 
 export const FuelProvider = ({ children }: FuelProviderProps) => {


### PR DESCRIPTION
The hooks that use `useFuel` don't work properly when the window is not yet loaded. This is because `useFuel` was casting null to a value, so it's consumers did not expect null.

For example, useProvider:
![image](https://github.com/FuelLabs/fuels-wallet/assets/47993817/e6fdb254-58fe-45f3-bfac-f33473112273)

This changes it to return `{ fuel: undefined }` when the context is null (i.e. the window is still loading). This is probably the simplest solution, but it doesn't tell users whether the window is loading or the extension is not installed.