### PR TITLE
feat: dispatch current account event with null when is not connected

### DIFF
--- a/.changeset/mean-trees-rescue.md
+++ b/.changeset/mean-trees-rescue.md
@@ -1,0 +1,6 @@
+---
+'fuels-wallet': minor
+'@fuel-wallet/sdk': minor
+---
+
+feat: dispatch current account null when current account is not connected

--- a/packages/app/playwright/crx/crx.test.ts
+++ b/packages/app/playwright/crx/crx.test.ts
@@ -629,7 +629,7 @@ test.describe('FuelWallet Extension', () => {
       expect(currentAccountEventResult).toEqual(currentAccount.address);
     });
 
-    await test.step('window.fuel.on("currentAccount") to a connected account', async () => {
+    await test.step('window.fuel.on("currentAccount") should be null when not connected', async () => {
       // Switch to account 2
       await switchAccount(popupPage, 'Account 2');
       await getByAriaLabel(popupPage, 'Accounts').click({ delay: 1000 });

--- a/packages/app/playwright/crx/crx.test.ts
+++ b/packages/app/playwright/crx/crx.test.ts
@@ -198,6 +198,7 @@ test.describe('FuelWallet Extension', () => {
       await createAccount();
       await createAccountFromPrivateKey(PRIVATE_KEY, 'Account 4');
       await createAccount();
+      await createAccount();
       await switchAccount(popupPage, 'Account 1');
       await hideAccount(popupPage, 'Account 5');
     });
@@ -606,7 +607,7 @@ test.describe('FuelWallet Extension', () => {
       await expect(networkSelector).toHaveText(/Fuel Testnet/);
     });
 
-    await test.step('window.fuel.on("currentAccount")', async () => {
+    await test.step('window.fuel.on("currentAccount") to a connected account', async () => {
       // Switch to account 2
       await switchAccount(popupPage, 'Account 2');
       await getByAriaLabel(popupPage, 'Accounts').click({ delay: 1000 });
@@ -626,6 +627,28 @@ test.describe('FuelWallet Extension', () => {
       // Check result
       const currentAccountEventResult = await onChangeAccountPromise;
       expect(currentAccountEventResult).toEqual(currentAccount.address);
+    });
+
+    await test.step('window.fuel.on("currentAccount") to a connected account', async () => {
+      // Switch to account 2
+      await switchAccount(popupPage, 'Account 2');
+      await getByAriaLabel(popupPage, 'Accounts').click({ delay: 1000 });
+      await getByAriaLabel(popupPage, `Close dialog`).click();
+
+      const onChangeAccountPromise = blankPage.evaluate(() => {
+        return new Promise((resolve) => {
+          window.fuel.on(window.fuel.events.currentAccount, (account) => {
+            resolve(account);
+          });
+        });
+      });
+
+      // Switch to account 1
+      await switchAccount(popupPage, 'Account 6');
+
+      // Check result
+      const currentAccountEventResult = await onChangeAccountPromise;
+      expect(currentAccountEventResult).toEqual(null);
     });
 
     await test.step('Auto lock fuel wallet', async () => {

--- a/packages/app/src/systems/CRX/background/services/DatabaseEvents.ts
+++ b/packages/app/src/systems/CRX/background/services/DatabaseEvents.ts
@@ -69,11 +69,13 @@ export class DatabaseEvents {
       const getOriginsForConnections = (connections: Array<Connection>) =>
         connections.map((c) => c.origin);
       const addressConnectedOrigins = getOriginsForConnections(
-        connections.filter((connection) =>
-          connection.accounts.includes(currentAccount?.address || '')
+        connections.filter((c) =>
+          c.accounts.includes(currentAccount?.address || '')
         )
       );
-      const addressNotConnectedOrigins = getOriginsForConnections(connections);
+      const addressNotConnectedOrigins = getOriginsForConnections(
+        connections.filter((c) => addressConnectedOrigins.includes(c.origin))
+      );
       const hasUnconnectedOrigins =
         addressNotConnectedOrigins.length !== addressConnectedOrigins.length;
 
@@ -92,7 +94,7 @@ export class DatabaseEvents {
       // by sending a null value
       if (hasUnconnectedOrigins) {
         this.communicationProtocol.broadcast(
-          addressConnectedOrigins,
+          addressNotConnectedOrigins,
           this.createEvents([
             {
               event: 'currentAccount',

--- a/packages/app/src/systems/CRX/background/services/DatabaseEvents.ts
+++ b/packages/app/src/systems/CRX/background/services/DatabaseEvents.ts
@@ -69,12 +69,10 @@ export class DatabaseEvents {
       const getOriginsForConnections = (connections: Array<Connection>) =>
         connections.map((c) => c.origin);
       const addressConnectedOrigins = getOriginsForConnections(
-        connections.filter((c) =>
-          c.accounts.includes(currentAccount?.address || '')
-        )
+        connections.filter((c) => c.accounts.includes(currentAccount.address))
       );
       const addressNotConnectedOrigins = getOriginsForConnections(
-        connections.filter((c) => addressConnectedOrigins.includes(c.origin))
+        connections.filter((c) => !addressConnectedOrigins.includes(c.origin))
       );
       const hasUnconnectedOrigins =
         addressNotConnectedOrigins.length !== addressConnectedOrigins.length;

--- a/packages/sdk/src/FuelWalletConnection.ts
+++ b/packages/sdk/src/FuelWalletConnection.ts
@@ -38,7 +38,7 @@ export class FuelWalletConnection extends WindowConnection {
     return this.client.request('accounts', {});
   }
 
-  async currentAccount(): Promise<string | null> {
+  async currentAccount(): Promise<string> {
     return this.client.request('currentAccount', {});
   }
 

--- a/packages/sdk/src/FuelWalletConnection.ts
+++ b/packages/sdk/src/FuelWalletConnection.ts
@@ -38,7 +38,7 @@ export class FuelWalletConnection extends WindowConnection {
     return this.client.request('accounts', {});
   }
 
-  async currentAccount(): Promise<string> {
+  async currentAccount(): Promise<string | null> {
     return this.client.request('currentAccount', {});
   }
 

--- a/packages/types/src/fuel.ts
+++ b/packages/types/src/fuel.ts
@@ -26,7 +26,7 @@ export type FuelEvents =
     }
   | {
       type: typeof FuelWalletEvents.currentAccount;
-      data: string;
+      data: string | null;
     }
   | {
       type: typeof FuelWalletEvents.connection;


### PR DESCRIPTION
On this PR;
- Change `currentEvent` to notify when the account is not connected with a `null` value.