### PR TITLE
fix: Remove unlisted dependency on React

### DIFF
--- a/.changeset/nine-eggs-build.md
+++ b/.changeset/nine-eggs-build.md
@@ -1,0 +1,5 @@
+---
+'@fuel-wallet/types': patch
+---
+
+fix: remove unlisted dependency

--- a/packages/types/src/error.ts
+++ b/packages/types/src/error.ts
@@ -1,9 +1,16 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import type React from 'react';
+
+// Copied from React.ErrorInfo
+interface ErrorInfo {
+  /**
+   * Captures which component contained the exception, and its ancestors.
+   */
+  componentStack: string;
+}
 
 export type FuelWalletError = {
   timestamp?: number;
   id?: string;
   error?: Error | ErrorEvent | { message: string; stack?: any };
-  reactError?: React.ErrorInfo;
+  reactError?: ErrorInfo;
 };


### PR DESCRIPTION
Although `@fuel-wallet/types` does not specify React as a dependency, it still depends on react (specifically `@types/react`). If the library is used in a project that doesn't have `@types/react` installed, Typescript will give the following error:

```
node_modules/@fuel-wallet/types/src/error.ts:2:24 - error TS2307: Cannot find module 'react' or its corresponding type declarations.

2 import type React from 'react';
```

Given that the import is just a simple interface, I've copied the interface into the file and removed the import.