### PR TITLE
chore: Fix broken link for Wallet SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Integrate your **DApp** using the [Wallet SDK](https://wallet.fuel.network/docs/
   - [📒 - List user accounts](https://wallet.fuel.network/docs/how-to-use/#list-user-accounts)
   - [✍️ - Signing a message](https://wallet.fuel.network/docs/how-to-use/#signing-a-message)
   - [✍️ - Transfering assets](https://wallet.fuel.network/docs/how-to-use/#transfering-assets)
-  - [📗 SDK API](https://wallet.fuel.network/docs/dev/getting-started/)
+  - [📗 SDK API](https://wallet.fuel.network/docs/dev/hooks-reference/)
 - [Contributing](https://wallet.fuel.network/docs/contributing/guide/)
   - [Contribution Guide](https://wallet.fuel.network/docs/contributing/guide/)
   - [Running Locally](https://wallet.fuel.network/docs/contributing/running-locally)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ FuelWallet is a crypto wallet used to interact with the Fuel Network. This proje
 
 [![Install Wallet](packages/docs/public/install-button.png)](https://wallet.fuel.network/docs/install/)
 
-Integrate your **DApp** using the [Wallet SDK](https://wallet.fuel.network/docs/api/)
+Integrate your **DApp** using the [Wallet SDK](https://wallet.fuel.network/docs/dev/getting-started/)
 
 ## 📗 Table of contents
 
@@ -24,7 +24,7 @@ Integrate your **DApp** using the [Wallet SDK](https://wallet.fuel.network/docs/
   - [📒 - List user accounts](https://wallet.fuel.network/docs/how-to-use/#list-user-accounts)
   - [✍️ - Signing a message](https://wallet.fuel.network/docs/how-to-use/#signing-a-message)
   - [✍️ - Transfering assets](https://wallet.fuel.network/docs/how-to-use/#transfering-assets)
-  - [📗 SDK API](https://wallet.fuel.network/docs/api/)
+  - [📗 SDK API](https://wallet.fuel.network/docs/dev/getting-started/)
 - [Contributing](https://wallet.fuel.network/docs/contributing/guide/)
   - [Contribution Guide](https://wallet.fuel.network/docs/contributing/guide/)
   - [Running Locally](https://wallet.fuel.network/docs/contributing/running-locally)


### PR DESCRIPTION
Old: https://wallet.fuel.network/docs/api/

New: https://wallet.fuel.network/docs/dev/getting-started/