### PR TITLE
ci: attach development build on release

### DIFF
--- a/.github/workflows/release-npm.yaml
+++ b/.github/workflows/release-npm.yaml
@@ -56,8 +56,6 @@ jobs:
       - name: Build Fuel Wallet Development
         run: pnpm build:crx
         env:
-          ## increase node.js m memory limit for building
-          ## with sourcemaps
           CRX_OUT: "dist-crx-dev"
           APP_VERSION_POSTFIX: "-development"
           NODE_OPTIONS: "--max-old-space-size=4096"

--- a/.github/workflows/release-npm.yaml
+++ b/.github/workflows/release-npm.yaml
@@ -59,12 +59,8 @@ jobs:
           ## increase node.js m memory limit for building
           ## with sourcemaps
           CRX_OUT: "dist-crx-dev"
-          APP_VERSION_POSTFIX: "development"
+          APP_VERSION_POSTFIX: "-development"
           NODE_OPTIONS: "--max-old-space-size=4096"
-
-      # Remove before merge
-      - name: Run list folder
-        run: ls ./dist
 
       - name: Create Release Pull Request or Publish to NPM
         id: changesets

--- a/.github/workflows/release-npm.yaml
+++ b/.github/workflows/release-npm.yaml
@@ -53,6 +53,19 @@ jobs:
           ## with sourcemaps
           NODE_OPTIONS: "--max-old-space-size=4096"
 
+      - name: Build Fuel Wallet Development
+        run: pnpm build:crx
+        env:
+          ## increase node.js m memory limit for building
+          ## with sourcemaps
+          CRX_OUT: "dist-crx-dev"
+          APP_VERSION_POSTFIX: "development"
+          NODE_OPTIONS: "--max-old-space-size=4096"
+
+      # Remove before merge
+      - name: Run list folder
+        run: ls ./dist
+
       - name: Create Release Pull Request or Publish to NPM
         id: changesets
         uses: FuelLabs/changesets-action@main

--- a/turbo.json
+++ b/turbo.json
@@ -17,7 +17,7 @@
     },
     "build:crx": {
       "dependsOn": ["^build"],
-      "outputs": ["dist-crx/**", "dist/fuel-wallet.zip"]
+      "outputs": ["dist-crx*/**", "dist/fuel-wallet*.zip"]
     },
     "build:web": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
On this PR;
- On every release add to the release tag the development build of the fuel-wallet.