### PR TITLE
feat: use connector image when icon is not available

### DIFF
--- a/.changeset/itchy-ducks-juggle.md
+++ b/.changeset/itchy-ducks-juggle.md
@@ -1,0 +1,5 @@
+---
+'@fuel-wallet/react': patch
+---
+
+Feat support for image from connector metadata

--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
       ]
     },
     "overrides": {
+      "follow-redirects": ">=1.15.4",
       "glob-parent@<5.1.2": ">=5.1.2",
       "json5": ">=2.2.2",
       "trim-newlines@<3.0.1": ">=3.0.1",

--- a/packages/react/src/ui/Connect/components/Connector/Connector.tsx
+++ b/packages/react/src/ui/Connect/components/Connector/Connector.tsx
@@ -25,6 +25,7 @@ export function Connector({ className, connector, theme }: ConnectorProps) {
     <div className={className}>
       <ConnectorImage>
         <ConnectorIcon
+          connectorMetadata={connector.metadata}
           connectorName={connector.name}
           size={100}
           theme={theme}

--- a/packages/react/src/ui/Connect/components/ConnectorIcon.tsx
+++ b/packages/react/src/ui/Connect/components/ConnectorIcon.tsx
@@ -1,13 +1,21 @@
+import type { ConnectorMetadata } from '@fuel-wallet/sdk';
+
 import type { SvgIconProps } from '../../types';
 import { FuelWalletDevelopmentIcon } from '../icons/FuelWalletDevelopmentIcon';
 import { FuelWalletIcon } from '../icons/FuelWalletIcon';
 import { FueletIcon } from '../icons/FueletIcon';
+import { getImageUrl } from '../utils/getImageUrl';
 
 type ConnectorIconProps = {
   connectorName: string;
+  connectorMetadata: ConnectorMetadata;
 } & SvgIconProps;
 
-export function ConnectorIcon({ connectorName, ...props }: ConnectorIconProps) {
+export function ConnectorIcon({
+  connectorName,
+  connectorMetadata,
+  ...props
+}: ConnectorIconProps) {
   switch (connectorName) {
     case 'Fuelet Wallet':
       return <FueletIcon {...props} />;
@@ -16,6 +24,11 @@ export function ConnectorIcon({ connectorName, ...props }: ConnectorIconProps) {
     case 'Fuel Wallet Development':
       return <FuelWalletDevelopmentIcon {...props} />;
     default:
-      return null;
+      return connectorMetadata.image ? (
+        <img
+          height={props.size}
+          src={getImageUrl(connectorMetadata, props.theme)}
+        />
+      ) : null;
   }
 }

--- a/packages/react/src/ui/Connect/components/ConnectorIcon.tsx
+++ b/packages/react/src/ui/Connect/components/ConnectorIcon.tsx
@@ -26,7 +26,8 @@ export function ConnectorIcon({
     default:
       return connectorMetadata.image ? (
         <img
-          height={props.size}
+          height={`${props.size}px`}
+          width={`${props.size}px`}
           src={getImageUrl(connectorMetadata, props.theme)}
         />
       ) : null;

--- a/packages/react/src/ui/Connect/components/Connectors/Connectors.tsx
+++ b/packages/react/src/ui/Connect/components/Connectors/Connectors.tsx
@@ -27,6 +27,7 @@ export function Connectors() {
           }}
         >
           <ConnectorIcon
+            connectorMetadata={connector.metadata}
             connectorName={connector.name}
             size={32}
             theme={theme}

--- a/packages/react/src/ui/Connect/components/Connectors/styles.tsx
+++ b/packages/react/src/ui/Connect/components/Connectors/styles.tsx
@@ -34,3 +34,7 @@ export const ConnectorList = styled.div`
 export const ConnectorName = styled.div`
   font-size: var(--fuel-font-size);
 `;
+
+export const ConnectorImg = styled.img`
+  object-fit: cover;
+`;

--- a/packages/react/src/ui/Connect/utils/getImageUrl.tsx
+++ b/packages/react/src/ui/Connect/utils/getImageUrl.tsx
@@ -1,7 +1,7 @@
-import type { FuelConnector } from '@fuel-wallet/sdk';
+import type { ConnectorMetadata } from '@fuel-wallet/sdk';
 
-export const getImageUrl = (theme: string, connector: FuelConnector) => {
-  const { image } = connector.metadata;
+export const getImageUrl = (connector: ConnectorMetadata, theme?: string) => {
+  const { image } = connector;
   if (typeof image === 'object') {
     return theme === 'dark' ? image.dark : image.light;
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  follow-redirects: '>=1.15.4'
   glob-parent@<5.1.2: '>=5.1.2'
   json5: '>=2.2.2'
   trim-newlines@<3.0.1: '>=3.0.1'
@@ -15663,8 +15664,8 @@ packages:
       - encoding
     dev: false
 
-  /follow-redirects@1.15.2:
-    resolution: {integrity: sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==}
+  /follow-redirects@1.15.4:
+    resolution: {integrity: sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -16612,7 +16613,7 @@ packages:
     engines: {node: '>=8.0.0'}
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.2
+      follow-redirects: 1.15.4
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug


### PR DESCRIPTION
On this PR;
- Use the image url provided by the connector when a image svg is not found inside the component.