### PR TITLE
fix: 'insertBefore' on 'Node' error by disabling translation

### DIFF
--- a/.changeset/gentle-melons-switch.md
+++ b/.changeset/gentle-melons-switch.md
@@ -1,0 +1,5 @@
+---
+'fuels-wallet': patch
+---
+
+fix: avoid dynamic dom manipulation by translators

--- a/packages/app/e2e.html
+++ b/packages/app/e2e.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" translate="no">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" href="/favicon.ico" />
@@ -11,8 +11,7 @@
     <meta name="msapplication-TileColor" content="#333333" />
     <meta name="theme-color" content="#333333" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="google" content="notranslate" />
   </head>
   <body></body>
 </html>

--- a/packages/app/index.html
+++ b/packages/app/index.html
@@ -1,9 +1,10 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" translate="no">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="google" content="notranslate" />
     <title>Fuels Wallet</title>
     <style>
       /* Avoid page to be empty during load

--- a/packages/app/popup.html
+++ b/packages/app/popup.html
@@ -1,9 +1,10 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" translate="no">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="google" content="notranslate" />
     <title>Fuels Wallet</title>
     <style>
       /* Avoid page to be empty during load


### PR DESCRIPTION
closes: #1029 

Based on the screenshots of the application, we could guess that the error happens because a kown issue with dom manipulation when using [translators](https://github.com/facebook/react/issues/11538).  For now I added the tags required to inform translators to not translate the page.