### PR TITLE
feat: automatically update seed phrase size

### DIFF
--- a/.changeset/shy-pandas-prove.md
+++ b/.changeset/shy-pandas-prove.md
@@ -1,0 +1,5 @@
+---
+'fuels-wallet': minor
+---
+
+Automatically identify seed phrase length and update the selected format to fit.


### PR DESCRIPTION
Automatically detect the length of a pasted seed phrase and adjust the selected format accordingly. 

If the size of the seed phrase does not match any predefined formats, the wallet will select the format that best fits the number of words.

### Examples
- If the user pastes a `13-word` seed phrase, the wallet will select the `15-word` format and leave 2 blank inputs.
- If the user pastes a `24-word` seed phrase, it will select the `24-word` format and fill out all inputs.
- In cases where the size of the seed phrase exceeds the largest supported format or is smaller than the smallest supported format, appropriate handling is implemented to ensure consistent behavior.

Additionally, this PR includes support for `multi-line paste`, allowing users to input seed phrases with each word on a separate line.

| `13-words` | `24-words` |
|--------|--------|
| <video src="https://github.com/FuelLabs/fuels-wallet/assets/7074983/979beac7-7663-44c4-a1e0-65ab6811cc94" /> | <video src="https://github.com/FuelLabs/fuels-wallet/assets/7074983/931014ea-af9c-4707-88bf-6e2924f6946c" /> |

