### PR TITLE
fix: display truncated account name correctly

### DIFF
--- a/.changeset/tender-mails-float.md
+++ b/.changeset/tender-mails-float.md
@@ -1,0 +1,5 @@
+---
+'fuels-wallet': patch
+---
+
+truncates long account name correctly

--- a/packages/app/src/systems/Account/components/AccountItem/AccountItem.tsx
+++ b/packages/app/src/systems/Account/components/AccountItem/AccountItem.tsx
@@ -184,11 +184,11 @@ const styles = {
         flex: 1,
         justifyContent: 'space-between',
       },
-      '.fuel_Avatar-generated': {
-        flexShrink: 0,
-      },
     },
 
+    '.fuel_Avatar-generated': {
+      flexShrink: 0,
+    },
     '.fuel_Button': {
       px: '$1 !important',
       color: '$intentsBase8',

--- a/packages/app/src/systems/Account/components/AccountItem/AccountItem.tsx
+++ b/packages/app/src/systems/Account/components/AccountItem/AccountItem.tsx
@@ -141,10 +141,9 @@ export const AccountItem: AccountItemComponent = ({
       aria-disabled={isDisabled}
       aria-label={account.name}
       data-compact={compact}
-      className="AccountItem"
     >
       <Avatar.Generated size={compact ? 'xsm' : 'md'} hash={account.address} />
-      <Box.Flex className="wrapper">
+      <Box.Flex className="wrapper" css={styles.content}>
         <Heading as="h6" css={styles.name}>
           {account.name}
         </Heading>
@@ -168,6 +167,10 @@ const styles = {
     background: '$cardBg',
     py: '$3 !important',
     cursor: 'pointer',
+
+    '& .fuel_Box-flex': {
+      minWidth: 0,
+    },
 
     '&[aria-disabled="true"]': {
       opacity: 0.5,
@@ -198,7 +201,14 @@ const styles = {
       color: '$intentsBase11',
     },
   }),
+  content: cssObj({
+    flex: 1,
+    minWidth: 0,
+  }),
   name: cssObj({
+    whiteSpace: 'nowrap',
+    textOverflow: 'ellipsis',
+    overflow: 'hidden',
     margin: 0,
   }),
   address: cssObj({

--- a/packages/app/src/systems/Account/components/BalanceWidget/BalanceWidget.tsx
+++ b/packages/app/src/systems/Account/components/BalanceWidget/BalanceWidget.tsx
@@ -53,7 +53,7 @@ export function BalanceWidget({
             hash={account?.address as string}
             css={{ boxShadow: '$sm' }}
           />
-          <Box.Stack gap="$1" css={{ flex: 1 }}>
+          <Box.Stack gap="$1" css={{ flex: 1, minWidth: 0 }}>
             <Heading as="h6" css={styles.name}>
               {account.name}
             </Heading>
@@ -130,6 +130,9 @@ const styles = {
     },
   }),
   name: cssObj({
+    whiteSpace: 'nowrap',
+    textOverflow: 'ellipsis',
+    overflow: 'hidden',
     lineHeight: '$tight',
     margin: '0px 0px -6px',
   }),


### PR DESCRIPTION
It fixes https://github.com/FuelLabs/fuels-wallet/issues/1095

| Before | After |
|-------------|-------------|
| <img width="382" alt="Screenshot 2024-02-28 at 15 01 31" src="https://github.com/FuelLabs/fuels-wallet/assets/7074983/64ffe835-0d0d-43a3-a300-c30d8bbcb54b"> | <img width="374" alt="Screenshot 2024-02-28 at 15 01 19" src="https://github.com/FuelLabs/fuels-wallet/assets/7074983/3f97ff3a-19b9-4943-91eb-1103458fcbae"> |

