### PR TITLE
(WIP) Bako ID integration

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -20,6 +20,7 @@
     "codegen": "graphql-codegen --config codegen.ts"
   },
   "dependencies": {
+    "@bako-id/sdk": "0.0.3",
     "@fontsource/source-code-pro": "5.0.13",
     "@fuel-ui/css": "0.23.2",
     "@fuel-ui/icons": "0.23.2",

--- a/packages/app/src/systems/Send/components/SendSelect/SendSelect.tsx
+++ b/packages/app/src/systems/Send/components/SendSelect/SendSelect.tsx
@@ -1,10 +1,15 @@
 import { cssObj } from '@fuel-ui/css';
-import { Box, Input, InputAmount, Text } from '@fuel-ui/react';
+import { Box, Form, Input, InputAmount, Text } from '@fuel-ui/react';
 import { motion } from 'framer-motion';
-import { BaseAssetId, DECIMAL_UNITS, bn } from 'fuels';
+import { Address, BaseAssetId, DECIMAL_UNITS, bn } from 'fuels';
 import { useEffect, useMemo } from 'react';
 import { AssetSelect } from '~/systems/Asset';
-import { ControlledField, Layout, animations } from '~/systems/Core';
+import {
+  ControlledField,
+  Layout,
+  animations,
+  shortAddress,
+} from '~/systems/Core';
 import { TxDetails } from '~/systems/Transaction';
 
 import type { UseSendReturn } from '../../hooks';
@@ -19,6 +24,7 @@ export function SendSelect({
   balanceAssetSelected,
   status,
   fee,
+  domain,
 }: SendSelectProps) {
   const assetId = form.watch('asset', '');
   // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
@@ -74,14 +80,28 @@ export function SendSelect({
               control={form.control}
               isInvalid={Boolean(form.formState.errors?.address)}
               render={({ field }) => (
-                <Input size="sm">
-                  <Input.Field
-                    {...field}
-                    id="address"
-                    aria-label="Address Input"
-                    placeholder="Enter a fuel address"
-                  />
-                </Input>
+                <>
+                  <Input size="sm">
+                    <Input.Field
+                      {...field}
+                      id="address"
+                      aria-label="Address Input"
+                      placeholder="Enter a fuel address or bako handle"
+                    />
+                  </Input>
+                  {domain && (
+                    <Form.HelperText
+                      css={{ fontSize: '$sm', fontWeight: '$normal' }}
+                    >
+                      Address of {field.value}:{' '}
+                      <Text as="b" css={{ fontWeight: '$bold' }}>
+                        {shortAddress(
+                          Address.fromB256(domain.resolver).toAddress()
+                        )}
+                      </Text>
+                    </Form.HelperText>
+                  )}
+                </>
               )}
             />
           </Box>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -159,6 +159,9 @@ importers:
 
   packages/app:
     dependencies:
+      '@bako-id/sdk':
+        specifier: 0.0.3
+        version: 0.0.3(fuels@0.77.0)
       '@fontsource/source-code-pro':
         specifier: 5.0.13
         version: 5.0.13
@@ -3315,11 +3318,11 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/compat-data': 7.23.5
+      '@babel/compat-data': 7.22.9
       '@babel/core': 7.24.0
-      '@babel/helper-compilation-targets': 7.23.6
+      '@babel/helper-compilation-targets': 7.22.10
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-validator-option': 7.23.5
+      '@babel/helper-validator-option': 7.22.5
       '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.22.5(@babel/core@7.24.0)
       '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.22.5(@babel/core@7.24.0)
       '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.24.0)
@@ -3390,7 +3393,7 @@ packages:
       '@babel/plugin-transform-unicode-regex': 7.22.5(@babel/core@7.24.0)
       '@babel/plugin-transform-unicode-sets-regex': 7.22.5(@babel/core@7.24.0)
       '@babel/preset-modules': 0.1.6(@babel/core@7.24.0)
-      '@babel/types': 7.24.0
+      '@babel/types': 7.22.11
       babel-plugin-polyfill-corejs2: 0.4.5(@babel/core@7.24.0)
       babel-plugin-polyfill-corejs3: 0.8.3(@babel/core@7.24.0)
       babel-plugin-polyfill-regenerator: 0.5.2(@babel/core@7.24.0)
@@ -3599,6 +3602,14 @@ packages:
       '@babel/helper-string-parser': 7.23.4
       '@babel/helper-validator-identifier': 7.22.20
       to-fast-properties: 2.0.0
+
+  /@bako-id/sdk@0.0.3(fuels@0.77.0):
+    resolution: {integrity: sha512-Ha+hc0JpquSwjLjJf3dwkbkGDmF0gdF14nudkptNc3lvZTHVta1EMfpBz6DI8z8HAiIEJcIdru4BZWC1hAjpew==}
+    peerDependencies:
+      fuels: 0.77.0
+    dependencies:
+      fuels: 0.77.0(dexie@3.2.4)
+    dev: false
 
   /@base2/pretty-print-object@1.0.1:
     resolution: {integrity: sha512-4iri8i1AqYHJE2DstZYkyEprg6Pq6sKx3xn5FpySk9sNhH7qN2LLlHJCfDTZRILNwQNPD7mATWM0TBui7uC1pA==}
@@ -4662,13 +4673,13 @@ packages:
     resolution: {integrity: sha512-eMmxNpoX/J1IPUjPGSZwo0Wh+7CEvdEMddP2Jxg1gQJXfGfht/FdW2D5XDFj3VMbOTUQlDIdZJY7uC6O6gjPoA==}
     dependencies:
       '@formatjs/ecma402-abstract': 1.17.0
-      tslib: 2.6.1
+      tslib: 2.6.2
     dev: false
 
   /@formatjs/intl-localematcher@0.4.0:
     resolution: {integrity: sha512-bRTd+rKomvfdS4QDlVJ6TA/Jx1F2h/TBVO5LjvhQ7QPPHp19oPNMIum7W2CMEReq/zPxpmCeB31F9+5gl/qtvw==}
     dependencies:
-      tslib: 2.6.1
+      tslib: 2.6.2
     dev: false
 
   /@fuel-ts/abi-coder@0.77.0:


### PR DESCRIPTION
This feature enables sending a transaction by handles in Bako, handle is `@` with a identifier name, an example:
`@fuel_network` 👇
```json 
{
  "owner": "0x000...",
  "resolver": "0x000...",
}
```

[Check Bako ID docs](https://docs.bako.id/)

---

Changes:
- [x] Modify address input to accept a `Bech32` or `@bako_handle`
- [x] Validations on input address
- [x] Fetch Bako handle and use the `resolver` address
- [x] Include `@bako-id/sdk@0.0.3` package
- [ ] Show handle name In transaction approve page  
- [ ] Create tests cases

