### PR TITLE
fix: turn off autocomplete on the private key input

### DIFF
--- a/packages/app/src/systems/Account/components/ImportAccountForm/ImportAccountForm.tsx
+++ b/packages/app/src/systems/Account/components/ImportAccountForm/ImportAccountForm.tsx
@@ -26,6 +26,8 @@ export const ImportAccountForm = ({
           <Input isDisabled={isLoading}>
             <Input.Field
               {...field}
+              autoComplete="off"
+              type="password"
               aria-label="Private Key"
               placeholder="Enter the private key to import from"
             />


### PR DESCRIPTION
- Disable `autoComplete` for the Private Key field (security reason).
- Make it `password` type as well.