### PR TITLE
chore: replace warning icon with a info circle icon on connected apps list

### DIFF
--- a/.changeset/short-feet-provide.md
+++ b/.changeset/short-feet-provide.md
@@ -1,0 +1,5 @@
+---
+"fuels-wallet": patch
+---
+
+chore: replaces a warning icon (orange) with a info icon (gray) from the connection list screen.

--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,5 +1,5 @@
 {
-  "**/*.(js|jsx|ts|tsx|md|json|mdx|html|css)": [
+  "**/*.(js|jsx|ts|tsx|json|html|css)": [
     "biome check --apply-unsafe --diagnostic-level=error --max-diagnostics=1000"
   ],
   ".{ts,tsx}": ["tsc --noEmit"]

--- a/examples/cra-dapp/package.json
+++ b/examples/cra-dapp/package.json
@@ -1,5 +1,6 @@
 {
   "name": "cra-dapp",
+  "type": "module",
   "version": "0.1.0",
   "private": true,
   "scripts": {

--- a/packages/app/src/systems/Settings/components/ConnectionList/ConnectionList.tsx
+++ b/packages/app/src/systems/Settings/components/ConnectionList/ConnectionList.tsx
@@ -46,11 +46,10 @@ export function ConnectionList({
             <Tooltip
               content={tooltipContent}
               as="div"
-              alignOffset={12}
               className="fuel_tooltip--container"
             >
               <Icon
-                icon={Icon.is('AlertTriangle')}
+                icon={Icon.is('InfoCircle')}
                 aria-label="Connection Alert"
               />
             </Tooltip>
@@ -118,7 +117,7 @@ const styles = {
     },
 
     '& > .fuel_Icon': {
-      color: '$intentsWarning9',
+      color: '$intentsBase9',
     },
 
     '.fuel_tooltip--container': {
@@ -129,7 +128,6 @@ const styles = {
   tooltipContent: cssObj({
     maxWidth: 250,
     textSize: 'sm',
-    textAlign: 'right',
     padding: '$0',
   }),
 };


### PR DESCRIPTION
- Fixes tooltip title text alignment.
- Replaces that orange `warning icon` with a gray `info circle icon`.

| ⚠️  Before |  ℹ️ After |
| ---- | ---- |
| <img width="335" alt="before" src="https://github.com/FuelLabs/fuels-wallet/assets/7074983/e32e8d25-22bb-45ed-8b1c-f0e6a6955ca2"> | <img width="332" alt="aftert" src="https://github.com/FuelLabs/fuels-wallet/assets/7074983/f6493205-68ad-4c72-8afe-f7867ce52cbe"> |
