### PR TITLE
fix: reset wallet manager to ensure correct generation of new accounts

### DIFF
--- a/.changeset/thick-feet-design.md
+++ b/.changeset/thick-feet-design.md
@@ -1,0 +1,11 @@
+---
+"fuels-wallet": patch
+---
+
+Previously, `Wallet Manager` was failing to clear properly when `db.clear();` is called.
+
+This led to wrong account addresses generation, as updates to the `IndexedDB` didn't reflect in the Wallet Manager's internal state, particularly the `#vaults` property.
+
+To resolve this issue, I implemented a manual call to `removeVault` during logout. 
+
+This ensures that each new wallet generated starts from scratch, free from interference by any previous mnemonic vault.

--- a/packages/app/src/systems/Account/components/AccountList/AccountList.tsx
+++ b/packages/app/src/systems/Account/components/AccountList/AccountList.tsx
@@ -17,7 +17,7 @@ export type AccountListProps = {
 };
 
 export function AccountList({
-  accounts,
+  accounts = [],
   canHideAccounts,
   hasHiddenAccounts,
   isLoading,
@@ -36,15 +36,14 @@ export function AccountList({
     <Box.Stack gap="$4">
       {isLoading && (
         <CardList>
-          {[...Array(3)].map((_, i) => {
-            // biome-ignore lint/suspicious/noArrayIndexKey: <explanation>
+          {[...Array(3).keys()].map((i) => {
             return <AccountItem.Loader key={i} />;
           })}
         </CardList>
       )}
       {!isLoading && (
         <CardList isClickable>
-          {(accounts ?? []).map((account) => (
+          {accounts.map((account) => (
             <AccountItem
               onPress={() => onPress?.(account)}
               onUpdate={onUpdate}

--- a/packages/app/src/systems/Account/machines/addAccountMachine.tsx
+++ b/packages/app/src/systems/Account/machines/addAccountMachine.tsx
@@ -95,9 +95,9 @@ export const addAccountMachine = createMachine(
             throw new Error('Account name already exists');
           }
 
-          // Get first vault, because the user can have multiple vaults added via private keys
-          const vaults = await VaultService.getVaults();
-          const [vault] = vaults;
+          // Get the first vault since users can have multiple vaults added via private keys,
+          // and the first vault is typically the initial one (generated or imported via mnemonic).
+          const [vault] = await VaultService.getVaults();
 
           // Add account to vault
           const accountVault = await VaultService.addAccount({
@@ -116,11 +116,11 @@ export const addAccountMachine = createMachine(
           });
 
           // set as active account
-          const activeAccount = await AccountService.setCurrentAccount({
+          const currentAccount = await AccountService.setCurrentAccount({
             address: account.address,
           });
 
-          return activeAccount;
+          return currentAccount;
         },
       }),
     },

--- a/packages/app/src/systems/Account/machines/addAccountMachine.tsx
+++ b/packages/app/src/systems/Account/machines/addAccountMachine.tsx
@@ -95,9 +95,9 @@ export const addAccountMachine = createMachine(
             throw new Error('Account name already exists');
           }
 
-          // Get latest vault
+          // Get first vault, because the user can have multiple vaults added via private keys
           const vaults = await VaultService.getVaults();
-          const [vault] = vaults.slice(-1);
+          const [vault] = vaults;
 
           // Add account to vault
           const accountVault = await VaultService.addAccount({

--- a/packages/app/src/systems/Account/machines/importAccountMachine.tsx
+++ b/packages/app/src/systems/Account/machines/importAccountMachine.tsx
@@ -112,7 +112,7 @@ export const importAccountMachine = createMachine(
           const account = await AccountService.addAccount({
             data: {
               name: input.name,
-              address: accountVault.address.toString(),
+              address: accountVault.address,
               publicKey: accountVault.publicKey,
               isHidden: false,
               vaultId: accountVault.vaultId,
@@ -121,7 +121,7 @@ export const importAccountMachine = createMachine(
 
           // set as active account
           const activeAccount = await AccountService.setCurrentAccount({
-            address: account.address.toString(),
+            address: account.address,
           });
 
           return activeAccount;

--- a/packages/app/src/systems/Core/services/core.ts
+++ b/packages/app/src/systems/Core/services/core.ts
@@ -1,9 +1,11 @@
+import { VaultService } from '~/systems/Vault';
 import { db } from '../utils/database';
 import { Storage } from '../utils/storage';
 
 // biome-ignore lint/complexity/noStaticOnlyClass: <explanation>
 export class CoreService {
   static async clear() {
+    await VaultService.clear();
     await db.clear();
     await Storage.clear();
   }

--- a/packages/app/src/systems/Settings/hooks/useExportVault.tsx
+++ b/packages/app/src/systems/Settings/hooks/useExportVault.tsx
@@ -1,5 +1,6 @@
 import { useInterpret, useSelector } from '@xstate/react';
 
+import { VaultService } from '~/systems/Vault';
 import type { ExportVaultMachineState } from '../machines';
 import { exportVaultMachine } from '../machines';
 
@@ -18,11 +19,14 @@ export function useExportVault() {
   const words = useSelector(service, selectors.words);
   const isUnlockOpened = useSelector(service, selectors.isUnlockOpened);
 
-  function exportVault(password: string) {
+  async function exportVault(password: string) {
+    const [vault] = await VaultService.getVaults();
+
     service.send({
       type: 'EXPORT_VAULT',
       input: {
         password,
+        vaultId: vault.vaultId,
       },
     });
   }

--- a/packages/app/src/systems/Settings/machines/exportVaultMachine.test.tsx
+++ b/packages/app/src/systems/Settings/machines/exportVaultMachine.test.tsx
@@ -30,17 +30,19 @@ describe('exportAccountMachine', () => {
 
     it('should be able to export account private key', async () => {
       state = await expectStateMatch(service, 'waitingPassword');
-      service.send('EXPORT_VAULT', { input: { password: pass } });
+      service.send('EXPORT_VAULT', { input: { password: pass, vaultId: 0 } });
       state = await expectStateMatch(service, 'done');
       expect(state.context.words.join(' ')).toBe(phrase);
     });
 
     it('should fail with incorrect password and be able to try again', async () => {
       state = await expectStateMatch(service, 'waitingPassword');
-      service.send('EXPORT_VAULT', { input: { password: `${pass}1` } });
+      service.send('EXPORT_VAULT', {
+        input: { password: `${pass}1`, vaultId: 0 },
+      });
       state = await expectStateMatch(service, 'waitingPassword');
       expect(state.context.error).toBe('Invalid password');
-      service.send('EXPORT_VAULT', { input: { password: pass } });
+      service.send('EXPORT_VAULT', { input: { password: pass, vaultId: 0 } });
       state = await expectStateMatch(service, 'done');
       expect(state.context.words.join(' ')).toStrictEqual(phrase);
     });

--- a/packages/app/src/systems/Settings/machines/exportVaultMachine.ts
+++ b/packages/app/src/systems/Settings/machines/exportVaultMachine.ts
@@ -17,7 +17,7 @@ type MachineContext = {
 
 type MachineEvents = {
   type: 'EXPORT_VAULT';
-  input: Omit<VaultInputs['exportVault'], 'vaultId'>;
+  input: VaultInputs['exportVault'];
 };
 
 export const exportVaultMachine = createMachine(
@@ -54,6 +54,7 @@ export const exportVaultMachine = createMachine(
               ev: Extract<MachineEvents, { type: 'EXPORT_VAULT' }>
             ) => ({
               password: ev.input.password,
+              vaultId: ev.input.vaultId,
             }),
           },
           onDone: [
@@ -94,12 +95,16 @@ export const exportVaultMachine = createMachine(
           if (!input?.password) {
             throw new Error('Password is required to export Vault!');
           }
+
+          if (input?.vaultId === undefined) {
+            throw new Error('Vault ID is required to export Vault!');
+          }
+
           const secret = await VaultService.exportVault({
-            ...input,
-            // TODO change once we add multiple vault management
-            // https://github.com/FuelLabs/fuels-wallet/issues/562
-            vaultId: 0,
+            password: input.password,
+            vaultId: input.vaultId,
           });
+
           return secret.split(' ');
         },
       }),

--- a/packages/app/src/systems/SignUp/services/signup.ts
+++ b/packages/app/src/systems/SignUp/services/signup.ts
@@ -22,7 +22,7 @@ export class SignUpService {
 
     // Ensure database is open
     await db.open();
-    // Clear databse on create
+    // Clear database on create
     await db.clear();
 
     // Add networks
@@ -38,9 +38,10 @@ export class SignUpService {
     });
 
     // Register the first account retuned from the vault
+    const name = await AccountService.generateAccountName();
     return AccountService.addAccount({
       data: {
-        name: 'Account 1',
+        name,
         address: account.address.toString(),
         publicKey: account.publicKey,
         isHidden: false,

--- a/packages/app/src/systems/Vault/services/VaultServer.ts
+++ b/packages/app/src/systems/Vault/services/VaultServer.ts
@@ -190,10 +190,9 @@ export class VaultServer extends EventEmitter {
 
   async clear(): Promise<void> {
     const vaults = await this.manager.getVaults();
-    const vaultIds = vaults.map((vault) => {
-      return this.manager.removeVault(vault.vaultId);
-    });
-    await Promise.all(vaultIds);
+    for (const vault of vaults) {
+      await this.manager.removeVault(vault.vaultId);
+    }
   }
 }
 

--- a/packages/app/src/systems/Vault/services/VaultServer.ts
+++ b/packages/app/src/systems/Vault/services/VaultServer.ts
@@ -51,7 +51,6 @@ export class VaultServer extends EventEmitter {
     'isLocked',
     'unlock',
     'createVault',
-    'removeVault',
     'getVaults',
     'getAccounts',
     'addAccount',
@@ -61,6 +60,7 @@ export class VaultServer extends EventEmitter {
     'exportVault',
     'exportPrivateKey',
     'lock',
+    'clear',
   ];
 
   constructor() {
@@ -100,10 +100,6 @@ export class VaultServer extends EventEmitter {
       publicKey: account.publicKey,
       vaultId: vault.vaultId,
     };
-  }
-
-  async removeVault(index: number): Promise<void> {
-    await this.manager.removeVault(index);
   }
 
   async getVaults() {
@@ -186,6 +182,14 @@ export class VaultServer extends EventEmitter {
   }: VaultInputs['exportPrivateKey']): Promise<string> {
     await this.manager.unlock(password);
     return this.manager.exportPrivateKey(Address.fromString(address));
+  }
+
+  async clear(): Promise<void> {
+    const vaults = this.manager.getVaults();
+    const vaultIds = vaults.map((vault) => {
+      return this.manager.removeVault(vault.vaultId);
+    });
+    await Promise.all(vaultIds);
   }
 }
 

--- a/packages/app/src/systems/Vault/services/VaultServer.ts
+++ b/packages/app/src/systems/Vault/services/VaultServer.ts
@@ -51,6 +51,7 @@ export class VaultServer extends EventEmitter {
     'isLocked',
     'unlock',
     'createVault',
+    'removeVault',
     'getVaults',
     'getAccounts',
     'addAccount',
@@ -92,12 +93,17 @@ export class VaultServer extends EventEmitter {
     const accounts = this.manager.getAccounts();
     const vaults = this.manager.getVaults();
     const [vault] = vaults.slice(-1);
-    const [account] = accounts;
+    const [account] = accounts.slice(-1);
+
     return {
       address: account.address.toString(),
       publicKey: account.publicKey,
       vaultId: vault.vaultId,
     };
+  }
+
+  async removeVault(index: number): Promise<void> {
+    await this.manager.removeVault(index);
   }
 
   async getVaults() {

--- a/packages/app/src/systems/Vault/services/VaultServer.ts
+++ b/packages/app/src/systems/Vault/services/VaultServer.ts
@@ -103,7 +103,7 @@ export class VaultServer extends EventEmitter {
   }
 
   async getVaults() {
-    return this.manager.getVaults();
+    return await this.manager.getVaults();
   }
 
   async isLocked(): Promise<boolean> {

--- a/packages/app/src/systems/Vault/services/VaultServer.ts
+++ b/packages/app/src/systems/Vault/services/VaultServer.ts
@@ -130,7 +130,7 @@ export class VaultServer extends EventEmitter {
   }
 
   async getAccounts(): Promise<Array<VaultAccount>> {
-    const accounts = this.manager.getAccounts();
+    const accounts = await this.manager.getAccounts();
     return accounts.map((ac) => ({
       address: ac.address.toString(),
       publicKey: ac.publicKey,

--- a/packages/app/src/systems/Vault/services/VaultServer.ts
+++ b/packages/app/src/systems/Vault/services/VaultServer.ts
@@ -185,7 +185,7 @@ export class VaultServer extends EventEmitter {
   }
 
   async clear(): Promise<void> {
-    const vaults = this.manager.getVaults();
+    const vaults = await this.manager.getVaults();
     const vaultIds = vaults.map((vault) => {
       return this.manager.removeVault(vault.vaultId);
     });

--- a/packages/app/src/systems/Vault/services/VaultServer.ts
+++ b/packages/app/src/systems/Vault/services/VaultServer.ts
@@ -51,6 +51,7 @@ export class VaultServer extends EventEmitter {
     'isLocked',
     'unlock',
     'createVault',
+    'getVaults',
     'getAccounts',
     'addAccount',
     'signMessage',
@@ -88,15 +89,19 @@ export class VaultServer extends EventEmitter {
       type,
       secret,
     });
-    const accounts = await this.manager.getAccounts();
-    const vaults = await this.manager.getVaults();
-    const vaultId = vaults.length - 1;
-    const [account] = accounts.slice(-1);
+    const accounts = this.manager.getAccounts();
+    const vaults = this.manager.getVaults();
+    const [vault] = vaults.slice(-1);
+    const [account] = accounts;
     return {
       address: account.address.toString(),
       publicKey: account.publicKey,
-      vaultId,
+      vaultId: vault.vaultId,
     };
+  }
+
+  async getVaults() {
+    return this.manager.getVaults();
   }
 
   async isLocked(): Promise<boolean> {
@@ -123,7 +128,7 @@ export class VaultServer extends EventEmitter {
   }
 
   async getAccounts(): Promise<Array<VaultAccount>> {
-    const accounts = await this.manager.getAccounts();
+    const accounts = this.manager.getAccounts();
     return accounts.map((ac) => ({
       address: ac.address.toString(),
       publicKey: ac.publicKey,

--- a/packages/app/src/systems/Vault/services/VaultServer.ts
+++ b/packages/app/src/systems/Vault/services/VaultServer.ts
@@ -90,8 +90,12 @@ export class VaultServer extends EventEmitter {
       type,
       secret,
     });
-    const accounts = this.manager.getAccounts();
-    const vaults = this.manager.getVaults();
+
+    const [vaults, accounts] = await Promise.all([
+      this.manager.getVaults(),
+      this.manager.getAccounts(),
+    ]);
+
     const [vault] = vaults.slice(-1);
     const [account] = accounts.slice(-1);
 


### PR DESCRIPTION
Previously, `Wallet Manager` was failing to clear properly when `db.clear();` is called.

This led to wrong account addresses generation, as updates to the `IndexedDB` didn't reflect in the Wallet Manager's internal state, particularly the `#vaults` property.

To resolve this issue, I implemented a manual call to `removeVault` during logout. 

This ensures that each new wallet generated starts from scratch, free from interference by any previous mnemonic vault.