### PR TITLE
feat: sync UI between connected apps list and edit screens

### DIFF
--- a/.changeset/rich-pens-wave.md
+++ b/.changeset/rich-pens-wave.md
@@ -1,0 +1,8 @@
+---
+"fuels-wallet": patch
+---
+
+- Display the full app URL when it's big (instead of truncating it). 
+- Sync the information displayed in the connected app `list` and `edit` screens.   
+- Improve how the URL are displayed, focusing on the `hostname` mostly.
+- Display only the first two initials on the Avatar when the page has a long title (2+ words).

--- a/packages/app/src/systems/Core/components/ConnectInfo/ConnectInfo.stories.tsx
+++ b/packages/app/src/systems/Core/components/ConnectInfo/ConnectInfo.stories.tsx
@@ -14,7 +14,7 @@ const URL = 'fuellabs.github.io/swayswap';
 
 export const Usage: StoryFn<ConnectInfoProps> = (args) => (
   <Box css={{ width: 300 }}>
-    <ConnectInfo {...args} origin={URL} account={MOCK_ACCOUNTS[0]} />
+    <ConnectInfo {...args} origin={URL} />
   </Box>
 );
 

--- a/packages/app/src/systems/Core/components/ConnectInfo/ConnectInfo.tsx
+++ b/packages/app/src/systems/Core/components/ConnectInfo/ConnectInfo.tsx
@@ -1,8 +1,7 @@
 import { cssObj } from '@fuel-ui/css';
 import { Avatar, Box, Card, Text } from '@fuel-ui/react';
-import type { Account } from '@fuel-wallet/types';
 
-import { parseUrl, truncate } from '../../utils';
+import { parseUrl, truncateByWordsNum } from '../../utils';
 
 import { ConnectInfoLoader } from './ConnectInfoLoader';
 
@@ -11,7 +10,6 @@ export type ConnectInfoProps = {
   title?: string;
   headerText: string;
   favIconUrl?: string;
-  account?: Account;
 };
 
 export function ConnectInfo({
@@ -27,18 +25,17 @@ export function ConnectInfo({
       )}
 
       <Card.Body css={styles.contentSection}>
-        <Box.Flex>
-          <Avatar
-            name={title || origin}
-            src={favIconUrl}
-            role="img"
-            size="sm"
-            aria-label={`${origin}-favicon`}
-          />
-        </Box.Flex>
-        <Box.Stack gap="$0">
+        <Avatar
+          name={truncateByWordsNum(title || origin, 2)}
+          src={favIconUrl}
+          role="img"
+          size="sm"
+          aria-label={`${origin}-favicon`}
+          css={styles.avatar}
+        />
+        <Box.Stack gap="$2" css={styles.stack}>
           <Text css={styles.title}>{title}</Text>
-          <Text css={styles.link}> {truncate(parseUrl(origin))} </Text>
+          <Text css={styles.link}>{parseUrl(origin)}</Text>
         </Box.Stack>
       </Card.Body>
     </Card>
@@ -55,19 +52,26 @@ const styles = {
   contentSection: cssObj({
     alignItems: 'center',
     display: 'flex',
-    gap: '$4',
-    py: '$2',
+    gap: '$3',
+    py: '$4',
+  }),
+  stack: cssObj({
+    minWidth: 0,
+  }),
+  avatar: cssObj({
+    flexShrink: 0,
   }),
   title: cssObj({
     fontSize: '$sm',
+    lineHeight: '$none',
     color: '$intentsBase12',
-    textOverflow: 'ellipsis',
-  }),
-  link: cssObj({
     overflow: 'hidden',
     whiteSpace: 'nowrap',
     textOverflow: 'ellipsis',
+  }),
+  link: cssObj({
     fontSize: '$sm',
+    lineHeight: '$none',
     color: '$intentsPrimary11',
     fontWeight: '$normal',
   }),

--- a/packages/app/src/systems/Core/utils/string.tsx
+++ b/packages/app/src/systems/Core/utils/string.tsx
@@ -2,7 +2,12 @@ export function getWordsFromValue(value?: string | string[]) {
   if (!Array.isArray(value)) {
     return value?.split(' ');
   }
+
   return value;
+}
+
+export function truncateByWordsNum(value: string, n: number) {
+  return value.split(' ').slice(0, n).join(' ');
 }
 
 export function getPhraseFromValue(value?: string | string[]) {
@@ -14,13 +19,6 @@ export function getPhraseFromValue(value?: string | string[]) {
 
 export const uniqueId = (size = 13) =>
   Math.random().toString(16).slice(2).slice(0, size);
-
-export const truncate = (str: string, length = 30) => {
-  if (str.length > length) {
-    return `${str.substring(0, length)}...`;
-  }
-  return str;
-};
 
 export type GetUniqueStringProps = {
   desired?: string;

--- a/packages/app/src/systems/Core/utils/url.ts
+++ b/packages/app/src/systems/Core/utils/url.ts
@@ -19,6 +19,11 @@ export function relativeUrl(path: string) {
   return urlJoin(import.meta.env.BASE_URL, path);
 }
 
-export function parseUrl(url: string) {
-  return url.replace(/http(s?):\/\//, '');
+export function parseUrl(value: string) {
+  try {
+    const url = new URL(value);
+    return url.hostname;
+  } catch (_err) {
+    return value.replace(/http(s?):\/\//, '');
+  }
 }

--- a/packages/app/src/systems/DApp/pages/TransactionRequest/TransactionRequest.tsx
+++ b/packages/app/src/systems/DApp/pages/TransactionRequest/TransactionRequest.tsx
@@ -20,7 +20,6 @@ export function TransactionRequest() {
   const Header = (
     <>
       <ConnectInfo
-        account={ctx.account}
         origin={ctx.input.origin!}
         favIconUrl={ctx.input.favIconUrl}
         title={ctx.input.title}

--- a/packages/app/src/systems/Settings/components/ConnectionEdit/ConnectionEdit.tsx
+++ b/packages/app/src/systems/Settings/components/ConnectionEdit/ConnectionEdit.tsx
@@ -99,7 +99,7 @@ const styles = {
     marginRight: '$1',
 
     '.fuel_Icon': {
-      color: '$intentsBase8',
+      color: 'currentColor',
     },
   }),
 };

--- a/packages/app/src/systems/Settings/components/ConnectionEdit/ConnectionEdit.tsx
+++ b/packages/app/src/systems/Settings/components/ConnectionEdit/ConnectionEdit.tsx
@@ -1,6 +1,4 @@
-import type { ThemeUtilsCSS } from '@fuel-ui/css';
 import { cssObj } from '@fuel-ui/css';
-import type { BoxProps } from '@fuel-ui/react';
 import { Box, CardList, Icon, Text } from '@fuel-ui/react';
 import { AnimatePresence, motion } from 'framer-motion';
 import { AccountItem } from '~/systems/Account';
@@ -16,8 +14,7 @@ import type { useConnections } from '../../hooks';
 
 export type ConnectionEditProps = ReturnType<typeof useConnections>;
 
-// biome-ignore lint/suspicious/noExplicitAny: <explanation>
-const MotionBox = motion<BoxProps & { css?: ThemeUtilsCSS }>(Box as any);
+const MotionBox = motion(Box);
 const MotionCardList = motion(CardList);
 
 export function ConnectionEdit({
@@ -27,14 +24,15 @@ export function ConnectionEdit({
 }: ConnectionEditProps) {
   if (!ctx.connection) return null;
   const { origin, title, favIconUrl } = ctx.connection;
+
   return (
     <Layout.Content>
       <Box.Stack gap="$3">
         <ConnectInfo
+          headerText="Edit your connection to:"
           origin={origin}
           favIconUrl={favIconUrl}
           title={title}
-          headerText="Edit your connection to:"
         />
         <Box.Flex css={styles.searchBar}>
           <SearchInput

--- a/packages/app/src/systems/Settings/components/ConnectionItem/ConnectionItem.tsx
+++ b/packages/app/src/systems/Settings/components/ConnectionItem/ConnectionItem.tsx
@@ -3,7 +3,7 @@ import { Avatar, Box, CardList, Icon, IconButton, Text } from '@fuel-ui/react';
 import type { Connection } from '@fuel-wallet/types';
 import { motion } from 'framer-motion';
 import type { FC } from 'react';
-import { animations, parseUrl, truncate } from '~/systems/Core';
+import { animations, parseUrl, truncateByWordsNum } from '~/systems/Core';
 
 import { ConnectionRemoveDialog } from '../ConnectionRemoveDialog';
 
@@ -28,9 +28,8 @@ export const ConnectionItem: ConnectionItemComponent = ({
   onEdit,
   onDelete,
 }) => {
-  const origin = connection.origin;
-  const accounts = connection.accounts.length;
-  const favIconUrl = connection.favIconUrl;
+  const { origin, title, favIconUrl, accounts } = connection;
+  const connectedAccounts = accounts.length;
 
   function handleConfirm() {
     onDelete(connection.origin);
@@ -62,14 +61,23 @@ export const ConnectionItem: ConnectionItemComponent = ({
           </ConnectionRemoveDialog>
         </Box.Flex>
       }
+      css={styles.container}
     >
-      <Avatar size="sm" name={origin} src={favIconUrl} css={styles.avatar} />
-      <Box css={styles.text}>
-        <Text>{truncate(parseUrl(origin))}</Text>
-        <Text>
-          {accounts} {`account${accounts > 1 ? 's' : ''}`} connected
+      <Avatar
+        size="sm"
+        role="img"
+        name={truncateByWordsNum(title || origin, 2)}
+        src={favIconUrl}
+        css={styles.avatar}
+      />
+      <Box.Stack gap="$2" css={styles.stack}>
+        <Text css={styles.title}>{title}</Text>
+        <Text css={styles.link}>{parseUrl(origin)}</Text>
+        <Text css={styles.accounts}>
+          {connectedAccounts} {`account${connectedAccounts > 1 ? 's' : ''}`}{' '}
+          connected
         </Text>
-      </Box>
+      </Box.Stack>
     </MotionCardItem>
   );
 };
@@ -88,24 +96,35 @@ const styles = {
       height: 'auto',
     },
   }),
-  avatar: cssObj({
-    height: 32,
-    width: 32,
+  container: cssObj({
+    '& .fuel_Box-flex': {
+      minWidth: 0,
+    },
   }),
-  text: cssObj({
-    '.fuel_Text:first-of-type': {
-      width: 160,
-      whiteSpace: 'nowrap',
-      overflow: 'hidden',
-      textOverflow: 'ellipsis',
-      textSize: 'sm',
-      fontWeight: '$normal',
-      color: '$intentsBase12',
-    },
-    '.fuel_Text:last-of-type': {
-      textSize: 'xs',
-      fontWeight: '$normal',
-      color: '$intentsBase8',
-    },
+  stack: cssObj({
+    minWidth: 0,
+  }),
+  avatar: cssObj({
+    flexShrink: 0,
+  }),
+  title: cssObj({
+    fontSize: '$sm',
+    lineHeight: '$none',
+    color: '$intentsBase12',
+    overflow: 'hidden',
+    whiteSpace: 'nowrap',
+    textOverflow: 'ellipsis',
+  }),
+  link: cssObj({
+    fontSize: '$sm',
+    lineHeight: '$none',
+    color: '$intentsPrimary11',
+    fontWeight: '$normal',
+  }),
+  accounts: cssObj({
+    fontSize: '$xs',
+    lineHeight: '$none',
+    fontWeight: '$normal',
+    color: '$intentsBase8',
   }),
 };


### PR DESCRIPTION
- Display the full app URL when it's big (instead of truncating it). Allowing the user to truly verify their connected apps.
- Sync the information displayed in the connected app `list` and `edit` screens to enhance consistency across our UI.
- Improve how the URL are displayed, focusing on the `hostname` mostly and use a native API instead of regex.
- Adjust the `Avatar` display to show only the first two initials letter when the page title is long (2+ words), preventing UI breakage.



|  List | Edit |
| --- | --- |
| <img width="345" alt="list" src="https://github.com/FuelLabs/fuels-wallet/assets/7074983/f4263c74-d211-493e-9beb-d42eaab247ba"> | <img width="346" alt="Screenshot 2024-03-26 at 17 22 40" src="https://github.com/FuelLabs/fuels-wallet/assets/7074983/33736052-9584-449c-9a19-afb8159f07d7"> |
