### PR TITLE
fix: auto-update reload action

### DIFF
--- a/.changeset/beige-olives-dress.md
+++ b/.changeset/beige-olives-dress.md
@@ -1,0 +1,5 @@
+---
+"fuels-wallet": patch
+---
+
+fix: auto-update in background to wait for update to be downloaded


### PR DESCRIPTION
Add listeners to ensure the update is downloaded and available, also check if the wallet is open if yes, schedule a reloadWallet for checking every 5 minutes. 