### PR TITLE
chore: Remove syntax highlighting of Sway files as Rust

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,0 @@
-# Syntax highlighting of sway files as rust
-*.sw linguist-language=Rust


### PR DESCRIPTION
Github recognizes Sway files and does not need them to be marked as Rust anymore.