### PR TITLE
feat: implement database connection watcher

### DIFF
--- a/.changeset/tricky-socks-invite.md
+++ b/.changeset/tricky-socks-invite.md
@@ -1,0 +1,5 @@
+---
+"fuels-wallet": patch
+---
+
+fix: database not recovering from error/closed state

--- a/packages/app/src/systems/Core/utils/database.ts
+++ b/packages/app/src/systems/Core/utils/database.ts
@@ -9,11 +9,13 @@ import type {
   NetworkData,
   Vault,
 } from '@fuel-wallet/types';
-import type { Table } from 'dexie';
+import type { DbEvents, PromiseExtended, Table } from 'dexie';
 import Dexie from 'dexie';
 import 'dexie-observable';
 import { DATABASE_VERSION, VITE_FUEL_PROVIDER_URL } from '~/config';
 import type { Transaction } from '~/systems/Transaction/types';
+
+type FailureEvents = Extract<keyof DbEvents, 'close' | 'blocked'>;
 
 export class FuelDB extends Dexie {
   vaults!: Table<Vault, string>;
@@ -24,6 +26,8 @@ export class FuelDB extends Dexie {
   assets!: Table<AssetData, string>;
   abis!: Table<AbiTable, string>;
   errors!: Table<FuelWalletError, string>;
+  integrityCheckInterval?: NodeJS.Timeout;
+  restartAttempts = 0;
   readonly alwaysOpen = true;
 
   constructor() {
@@ -51,16 +55,70 @@ export class FuelDB extends Dexie {
           id: createUUID(),
         });
       });
-    this.on('blocked', () => this.restart('closed'));
-    this.on('close', () => this.restart('blocked'));
+    this.on('blocked', () => this.restart('blocked'));
+    this.on('close', () => this.restart('close'));
+    this.on('message', (e) => {
+      console.log('fsk changed', e);
+    });
   }
 
-  async restart(eventName: 'blocked' | 'closed') {
+  open() {
+    return this.safeOpen().finally(() =>
+      this.watchConnection()
+    ) as PromiseExtended<Dexie>;
+  }
+
+  close(safeClose = false) {
+    if (safeClose) {
+      this.restartAttempts = 0;
+      clearInterval(this.integrityCheckInterval);
+    }
+    return super.close();
+  }
+
+  async safeOpen() {
+    try {
+      const result = await super.open();
+      this.restartAttempts = 0;
+      return result;
+    } catch (err) {
+      console.error('Failed to restart DB. Sending signal for restart');
+      this.restart('blocked');
+      throw err;
+    }
+  }
+
+  async ensureDatabaseOpen() {
+    if (this.isOpen() && !this.hasBeenClosed() && !this.hasFailed()) return;
+
+    if (this.restartAttempts > 3) {
+      console.error('Reached max attempts to open DB. Sending restart signal.');
+      this.restart('blocked');
+      return;
+    }
+
+    this.restartAttempts += 1;
+    console.warn('DB is not open. Attempting restart.');
+    await this.safeOpen();
+  }
+
+  watchConnection() {
+    if (!this.alwaysOpen) return;
+
+    clearInterval(this.integrityCheckInterval);
+    this.integrityCheckInterval = setInterval(() => {
+      this.ensureDatabaseOpen();
+    }, 1000);
+  }
+
+  async restart(eventName: FailureEvents) {
     if (!this.alwaysOpen) {
       return;
     }
-    if (eventName !== 'closed') {
-      this.close();
+    if (eventName === 'close') {
+      clearInterval(this.integrityCheckInterval);
+    } else {
+      this.close(true);
     }
 
     this.open();


### PR DESCRIPTION
## Description
- There are situations where the DB is closed and doesn't fire a close/blocked event, so I've implemented an interval that doas a health check and attempts to restart otherwise;
- Fixes extension side DB closing until extension reload after the Vault is locked, the browser hangs for a while and other edge cases scenarios where

Note: The DB is instantiated in both the extension's main thread and the service worker, we might want to refactor to instantiate and access it only in the service worker, using  Chrome's Messaging API as a communication layer with the main thread. It'd be safer and less problematic to debug than having 2 connections.

## Testing:
### **Reproducing the Error**
I'd suggest going to the `Send` screen (first screen after clicking send), filling out the form, waiting for the extension's lock time, then clicking send.  
> _You can also set a debugger point in `useSend.tsx` in devtools, in the first line of `submit` function; this forces a de-sync between the extension and service worker right before the auto lock (you'll still have to wait the auto-lock time out)._

### **Expected behavior**
- Toast errors about DB connection shouldn't show continuously
- The extension should work normally after unlocking.