### PR TITLE
feat: rename ignition network to fuel sepolia testnet

### DIFF
--- a/.changeset/curvy-hotels-design.md
+++ b/.changeset/curvy-hotels-design.md
@@ -1,0 +1,7 @@
+---
+"@fuel-wallet/connections": minor
+"@fuel-wallet/types": minor
+"fuels-wallet": minor
+---
+
+Rename network to `Fuel Sepolia Testnet`

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -2,7 +2,7 @@
   "name": "fuels-wallet",
   "private": true,
   "version": "0.20.0",
-  "database": "16",
+  "database": "17",
   "scripts": {
     "build:all": "run-s build:web build:crx build:storybook",
     "build:web": "./scripts/build.sh --app=vite",

--- a/packages/app/playwright/crx/crx.test.ts
+++ b/packages/app/playwright/crx/crx.test.ts
@@ -568,7 +568,7 @@ test.describe('FuelWallet Extension', () => {
 
       // Check if added network is selected
       let networkSelector = getByAriaLabel(popupPage, 'Selected Network');
-      await expect(networkSelector).toHaveText(/Ignition/);
+      await expect(networkSelector).toHaveText(/Fuel Sepolia Testnet/);
 
       // Remove added network
       await networkSelector.click();
@@ -594,7 +594,7 @@ test.describe('FuelWallet Extension', () => {
 
       // Check if re-added network is selected
       networkSelector = getByAriaLabel(popupPage, 'Selected Network');
-      await expect(networkSelector).toHaveText(/Ignition/);
+      await expect(networkSelector).toHaveText(/Fuel Sepolia Testnet/);
     });
 
     await test.step('window.fuel.on("currentAccount") to a connected account', async () => {

--- a/packages/app/playwright/e2e/Networks.test.ts
+++ b/packages/app/playwright/e2e/Networks.test.ts
@@ -89,12 +89,12 @@ test.describe('Networks', () => {
     const urlInput = getInputByName(page, 'url');
     await expect(urlInput).toBeFocused();
     await urlInput.fill('https://testnet.fuel.network/v1/graphql');
-    await hasText(page, /Ignition/i, 0, 15000);
+    await hasText(page, /Fuel Sepolia Testnet/i, 0, 15000);
     await expect(buttonCreate).toBeEnabled();
     await buttonCreate.click();
     // Wait for save and close popup;
     await page.waitForTimeout(2000);
     await reload(page);
-    await hasText(page, /Ignition/i);
+    await hasText(page, /Fuel Sepolia Testnet/i);
   });
 });

--- a/packages/app/src/systems/Core/utils/database.ts
+++ b/packages/app/src/systems/Core/utils/database.ts
@@ -47,9 +47,9 @@ export class FuelDB extends Dexie {
         const networks = tx.table('networks');
         // Clean networks
         await networks.clear();
-        // Insert beta-5 network
+        // Insert testnet network
         await networks.add({
-          name: 'Ignition',
+          name: 'Fuel Sepolia Testnet',
           url: VITE_FUEL_PROVIDER_URL,
           isSelected: true,
           id: createUUID(),


### PR DESCRIPTION
Rename ignition network to `Fuel Sepolia Testnet`.

| 📷  |
| --- |
| <img width="384" alt="Screenshot 2024-05-31 at 14 05 31" src="https://github.com/FuelLabs/fuels-wallet/assets/7074983/6235df60-82f6-45a2-9ff7-dc7ae17f49bc"> |
