### PR TITLE
docs: add useTransactionResult and deprecate useTransactionReceipts 

### DIFF
--- a/packages/docs/docs/dev/hooks-reference.mdx
+++ b/packages/docs/docs/dev/hooks-reference.mdx
@@ -77,7 +77,7 @@ handleConnect();
 
 ## `useConnectors`
 
-Retrieves a list of available connectors `<Array<FuelConnector>>` for connecting to Fuel.
+Retrieves a list of available connectors `Array<FuelConnector>` for connecting to Fuel.
 
 ```tsx
 const { connectors } = useConnectors();
@@ -148,9 +148,9 @@ const { transaction } = useTransaction({ txId: '0xd7ad97...' });
 
 [See the source file](https://github.com/FuelLabs/fuels-npm-packs/tree/main/packages/react/src/hooks/useTransaction.ts)
 
-## `useTransactionReceipts`
+## `useTransactionReceipts` <BadgeDeprecated tooltip={<>This hook is deprecated and will be removed in a future release.<br />Please use <b>useTransactionResult</b> with the <b>select</b> function in the <b>query</b> parameter instead.</>} />
 
-Retrieves transaction receipts `<Array<TransactionResultReceipt>>` associated with a specific transaction ID using the `useFuel` hook.
+Retrieves transaction receipts `Array<TransactionResultReceipt>` associated with a specific transaction ID using the `useFuel` hook.
 
 ```tsx
 const { transactionReceipts } = useTransactionReceipts({

--- a/packages/docs/docs/dev/hooks-reference.mdx
+++ b/packages/docs/docs/dev/hooks-reference.mdx
@@ -148,7 +148,7 @@ const { transaction } = useTransaction({ txId: '0xd7ad97...' });
 
 [See the source file](https://github.com/FuelLabs/fuels-npm-packs/tree/main/packages/react/src/hooks/useTransaction.ts)
 
-## <Code data-decoration="line-through">useTransactionReceipts</Code> <BadgeDeprecated tooltip={<>This hook is deprecated and will be removed in a future release.<br />Please use <b>useTransactionResult</b> with the <b>select</b> function in the <b>query</b> parameter instead.</>} />
+## <HStack align="center" justify="flex-start" direction="row" wrap="nowrap"> <Code data-decoration="line-through">useTransactionReceipts</Code> <BadgeDeprecated tooltip={<>This hook is deprecated and will be removed in a future release.<br />Please use <b>useTransactionResult</b> with the <b>select</b> function in the <b>query</b> parameter instead.</>} /> </HStack>
 
 Retrieves transaction receipts `Array<TransactionResultReceipt>` associated with a specific transaction ID using the `useFuel` hook.
 

--- a/packages/docs/docs/dev/hooks-reference.mdx
+++ b/packages/docs/docs/dev/hooks-reference.mdx
@@ -143,7 +143,7 @@ const { provider } = useProvider();
 Retrieves transaction information associated with a specific transaction ID by using the `provider.getTransaction` method.
 
 ```tsx
-const { transaction } = useTransaction({ txId: 'fuel1r20zhd...' });
+const { transaction } = useTransaction({ txId: '0xd7ad97...' });
 ```
 
 [See the source file](https://github.com/FuelLabs/fuels-npm-packs/tree/main/packages/react/src/hooks/useTransaction.ts)
@@ -154,15 +154,59 @@ Retrieves transaction receipts `<Array<TransactionResultReceipt>>` associated wi
 
 ```tsx
 const { transactionReceipts } = useTransactionReceipts({
-  txId: 'fuel1r20zhd...',
+  txId: '0xd7ad97...',
 });
 ```
 
 [See the source file](https://github.com/FuelLabs/fuels-npm-packs/tree/main/packages/react/src/hooks/useTransactionReceipts.ts)
 
+## `useTransactionResult`
+
+Retrieves a transaction result associated with a specific transaction ID.  
+This is accomplished internally using the `provider.getTransactionResponse` method along with the `TransactionResponse.waitForResult` method.
+
+##### Basic Usage
+
+```tsx
+const { transactionResult } = useTransactionResult({ txId: '0xd7ad97...' });
+```
+
+##### Custom Name
+
+Customize the `data` attribute of the most recently resolved data.
+
+```tsx
+const { anything } = useTransactionResult({ 
+  txId: '0xd7ad97...',
+  query: {
+    name: 'anything',
+  },
+});
+```
+
+##### Custom Selector
+
+Transform or select a specific part of the data returned by the query function.  
+This modification affects the returned data value but does not impact the data stored in the query cache.
+
+```tsx
+const { receipts } = useTransactionResult({ 
+  txId: '0xd7ad97...',
+  query: {
+    // you can omit custom "name" if you don't need it
+    name: 'receipts',
+    // ((data: TransactionResult<TransactionType> | null) => T) | undefined
+    select: (data) => data?.receipts,
+  },
+});
+```
+
+
+[See the source file](https://github.com/FuelLabs/fuels-npm-packs/tree/main/packages/react/src/hooks/useTransactionResult.ts)
+
 ## `useWallet`
 
-Retrieves wallet instance `<Account | null | undefined>` and ensures the presence of a valid address and fuel instance.
+Retrieves wallet instance `<Account | null>` and ensures the presence of a valid address and fuel instance.
 
 ```tsx
 const { wallet } = useWallet({ address: 'fuel1r20zhd...' });

--- a/packages/docs/docs/dev/hooks-reference.mdx
+++ b/packages/docs/docs/dev/hooks-reference.mdx
@@ -148,7 +148,7 @@ const { transaction } = useTransaction({ txId: '0xd7ad97...' });
 
 [See the source file](https://github.com/FuelLabs/fuels-npm-packs/tree/main/packages/react/src/hooks/useTransaction.ts)
 
-## `useTransactionReceipts` <BadgeDeprecated tooltip={<>This hook is deprecated and will be removed in a future release.<br />Please use <b>useTransactionResult</b> with the <b>select</b> function in the <b>query</b> parameter instead.</>} />
+## <Code data-decoration="line-through">useTransactionReceipts</Code> <BadgeDeprecated tooltip={<>This hook is deprecated and will be removed in a future release.<br />Please use <b>useTransactionResult</b> with the <b>select</b> function in the <b>query</b> parameter instead.</>} />
 
 Retrieves transaction receipts `Array<TransactionResultReceipt>` associated with a specific transaction ID using the `useFuel` hook.
 

--- a/packages/docs/docs/dev/hooks-reference.mdx
+++ b/packages/docs/docs/dev/hooks-reference.mdx
@@ -140,7 +140,7 @@ const { provider } = useProvider();
 
 ## `useTransaction`
 
-Retrieves transaction information associated with a specific transaction ID by using the `provider.getTransaction` method.
+Retrieves transaction information associated with a specific transaction ID.
 
 ```tsx
 const { transaction } = useTransaction({ txId: '0xd7ad97...' });
@@ -163,7 +163,6 @@ const { transactionReceipts } = useTransactionReceipts({
 ## `useTransactionResult`
 
 Retrieves a transaction result associated with a specific transaction ID.  
-This is accomplished internally using the `provider.getTransactionResponse` method along with the `TransactionResponse.waitForResult` method.
 
 ##### Basic Usage
 

--- a/packages/docs/spell-check-custom-words.txt
+++ b/packages/docs/spell-check-custom-words.txt
@@ -99,3 +99,6 @@ assetId
 contractId
 boolean
 tanstack
+BadgeDeprecated
+tooltip
+useTransactionResult

--- a/packages/docs/src/components/BadgeDeprecated.tsx
+++ b/packages/docs/src/components/BadgeDeprecated.tsx
@@ -1,0 +1,15 @@
+import { Badge, Tooltip } from '@fuel-ui/react';
+
+type BadgeDeprecatedProps = {
+  tooltip: React.ReactNode;
+};
+
+export function BadgeDeprecated({ tooltip }: BadgeDeprecatedProps) {
+  return (
+    <Tooltip content={tooltip} delayDuration={0}>
+      <Badge variant="ghost" intent="warning" css={{ fontSize: '0.7rem' }}>
+        Deprecated
+      </Badge>
+    </Tooltip>
+  );
+}

--- a/packages/docs/src/components/BadgeDeprecated.tsx
+++ b/packages/docs/src/components/BadgeDeprecated.tsx
@@ -20,13 +20,13 @@ export function BadgeDeprecated({ tooltip }: BadgeDeprecatedProps) {
           columnGap: '$1',
         }}
       >
+        <span>Deprecated</span>
         <Icon
-          icon="HelpCircle"
+          icon="InfoCircle"
           className="main-icon"
           aria-label="Menu Icon"
-          size={14}
+          size={16}
         />
-        <span>Deprecated</span>
       </Badge>
     </Tooltip>
   );

--- a/packages/docs/src/components/BadgeDeprecated.tsx
+++ b/packages/docs/src/components/BadgeDeprecated.tsx
@@ -1,4 +1,4 @@
-import { Badge, Tooltip } from '@fuel-ui/react';
+import { Badge, HStack, Icon, Tooltip } from '@fuel-ui/react';
 
 type BadgeDeprecatedProps = {
   tooltip: React.ReactNode;
@@ -7,8 +7,26 @@ type BadgeDeprecatedProps = {
 export function BadgeDeprecated({ tooltip }: BadgeDeprecatedProps) {
   return (
     <Tooltip content={tooltip} delayDuration={0}>
-      <Badge variant="ghost" intent="warning" css={{ fontSize: '0.7rem' }}>
-        Deprecated
+      <Badge
+        as="div"
+        variant="ghost"
+        intent="warning"
+        css={{
+          fontSize: '0.7rem',
+          lineHeight: 'normal',
+          display: 'inline-flex',
+          alignItems: 'center',
+          flexDirection: 'row',
+          columnGap: '$1',
+        }}
+      >
+        <Icon
+          icon="HelpCircle"
+          className="main-icon"
+          aria-label="Menu Icon"
+          size={14}
+        />
+        <span>Deprecated</span>
       </Badge>
     </Tooltip>
   );

--- a/packages/docs/src/components/Code.tsx
+++ b/packages/docs/src/components/Code.tsx
@@ -16,5 +16,8 @@ const styles = {
     background: '$intentsBase3',
     color: '$intentsBase10',
     fontSize: '0.9rem',
+    '&[data-decoration=line-through]': {
+      textDecoration: 'line-through',
+    },
   }),
 };

--- a/packages/docs/src/components/Code.tsx
+++ b/packages/docs/src/components/Code.tsx
@@ -16,6 +16,7 @@ const styles = {
     background: '$intentsBase3',
     color: '$intentsBase10',
     fontSize: '0.9rem',
+    lineHeight: 'normal',
     '&[data-decoration=line-through]': {
       textDecoration: 'line-through',
     },

--- a/packages/docs/src/components/Provider.tsx
+++ b/packages/docs/src/components/Provider.tsx
@@ -45,6 +45,7 @@ const components = {
   pre: Pre,
   p: Paragraph,
   code: Code,
+  Code,
   blockquote: Blockquote,
   table: Table,
   td: TD,

--- a/packages/docs/src/components/Provider.tsx
+++ b/packages/docs/src/components/Provider.tsx
@@ -1,4 +1,5 @@
 import {
+  HStack,
   ThemeProvider,
   createTheme,
   loadIcons,
@@ -59,6 +60,7 @@ const components = {
   Examples,
   Demo,
   DownloadWalletZip,
+  HStack,
 };
 
 type ProviderProps = {

--- a/packages/docs/src/components/Provider.tsx
+++ b/packages/docs/src/components/Provider.tsx
@@ -16,6 +16,7 @@ import type { ReactNode } from 'react';
 
 import * as Examples from '../../examples';
 
+import { BadgeDeprecated } from './BadgeDeprecated';
 import { Blockquote } from './Blockquote';
 import { Code } from './Code';
 import { CodeImport } from './CodeImport';
@@ -33,6 +34,7 @@ import { SDKSection } from './SDKSection';
 import { TD, TH, Table } from './Table';
 
 const components = {
+  BadgeDeprecated,
   a: Link,
   h1: Heading,
   h2: Heading,


### PR DESCRIPTION
- Deprecate `useTransactionReceipts` in the documentation.
- Add `useTransactionResult` to the documentation.


| :camera: `useTransactionReceipts` |
| --- |
| <img width="1073" alt="Screenshot 2024-06-03 at 21 28 13" src="https://github.com/FuelLabs/fuels-wallet/assets/7074983/d4bd1b27-7457-4a75-ac1d-810a6bbe389b"> |



| :camera: `useTransactionResult` |
| --- |
| <img width="947" alt="Screenshot 2024-06-03 at 14 49 20" src="https://github.com/FuelLabs/fuels-wallet/assets/7074983/5d8f70b5-ad84-46fa-86aa-cb084d9bdb3e"> |

