### PR TITLE
fix: extension freezing when validating a specifically malformed network URL

### DIFF
--- a/.changeset/pink-ties-report.md
+++ b/.changeset/pink-ties-report.md
@@ -1,0 +1,5 @@
+---
+"fuels-wallet": patch
+---
+
+Fixed extension freezing when validating a specifically malformed network URL

--- a/packages/app/src/systems/Network/utils/url.test.tsx
+++ b/packages/app/src/systems/Network/utils/url.test.tsx
@@ -83,6 +83,14 @@ describe('Network URL Utilities', () => {
 
       // URLs with illegal characters in the domain
       expect(isValidNetworkUrl('http://exa$mple.com')).toBe(false);
+
+      //Tests if authentication URL without ":" should fail without hanging the V8 Thread
+      // https://issues.chromium.org/issues/365066528
+      expect(
+        isValidNetworkUrl(
+          'https://fffffff10abbxyFfffFFOfFffF0Fff@supernet.ffff.network/v1/graphql'
+        )
+      ).toBe(false);
     });
   });
 

--- a/packages/app/src/systems/Network/utils/url.tsx
+++ b/packages/app/src/systems/Network/utils/url.tsx
@@ -1,22 +1,30 @@
 import { DEVNET_NETWORK_URL, TESTNET_NETWORK_URL } from 'fuels';
 
+const URL_PATTERN = new RegExp(
+  '^(?<protocol>https?:\\/\\/)' +
+    '(?:(?<auth>[\\w%.~+-]+:[\\w%.~+-]+)@)?' +
+    '(?<host>' +
+    '(?:' +
+    '(?:[\\w-]+\\.)*[a-z]{2,}|' + // Domain name
+    '(?:\\d{1,3}\\.){3}\\d{1,3}' + // IP address
+    ')' +
+    ')' +
+    '(?::(?<port>\\d+))?' +
+    '(?<path>\\/[\\w%.~+-]*)*?' +
+    '(?<query>\\?[\\w%.~+=&-]*)?' +
+    '(?<fragment>#[\\w%.-]*)?' +
+    '$',
+  'gi'
+);
+
 export function isValidNetworkUrl(url?: string) {
   if (!url) return false;
 
-  // ^https?:\/\/(?:[a-z\d%_.~+-]+:[a-z\d%_.~+-]+@)?((([a-z\d]([a-z\d-]*[a-z\d])*)\.{0,1})+[a-z]{2,}|((\d{1,3}\.){3}\d{1,3}))(\:\d+)?(\/[-a-z\d%_.-]*)*?(\?[&a-z\d%_.~+=-]*)?([a-zA-Z\d]*)$
-  const pattern = new RegExp(
-    '^https?:\\/\\/' + // Matches the protocol (http or https)
-      '(?:[a-z\\d%_.~+-]+:[a-z\\d%_.~+-]+@)?' + // Optional basic auth (user:password@)
-      '((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.{0,1})+[a-z]{2,}|' + // Matches domain name
-      '((\\d{1,3}\\.){3}\\d{1,3}))' + // Or matches IP address
-      '(\\:\\d+)?' + // Optional port number
-      '(\\/[-a-z\\d%_.-]*)*?' + // Makes any path optional, including no path, and multiple paths
-      '(\\?[&a-z\\d%_.~+=-]*)?' + // Optional query parameters
-      '([a-zA-Z\\d]*)$', // mnake sure it blocks any extra special character in the URL
-    'i' // Case-insensitive
-  );
-  return pattern.test(url);
+  // Reset lastIndex to 0 before each test
+  URL_PATTERN.lastIndex = 0;
+  return URL_PATTERN.test(url);
 }
+
 export function isNetworkTestnet(url: string) {
   return url.includes(TESTNET_NETWORK_URL);
 }


### PR DESCRIPTION
## Context
With the previous regular expression, trying to parse a specifically malformed string would block the V8 thread (good catch @LuizAsFight!). More info on the issue can be read about [here](https://issues.chromium.org/issues/365066528).

## Changes
- Optimized expression
- Added named matching groups
- Moved regular expression to be a global, avoiding instantiating it at the method's execution time

Closes #1460