### PR TITLE
Refine Network Addition Validation

### DIFF
--- a/packages/app/src/systems/Network/machines/networksMachine.ts
+++ b/packages/app/src/systems/Network/machines/networksMachine.ts
@@ -221,13 +221,16 @@ export const networksMachine = createMachine(
           await NetworkService.validateNetworkExists(input.data);
           await NetworkService.validateNetworkVersion(input.data);
 
+          const nameCheck = await NetworkService.checkNetworkByName({name: input.data.name});
+          const DateNow = new Date().toISOString();
+
           const provider = await Provider.create(input.data.url);
           const chainId = provider.getChainId();
 
           const createdNetwork = await NetworkService.addNetwork({
             data: {
               chainId,
-              name: input.data.name,
+              name: nameCheck == true ? input.data.name + ' ' + DateNow : input.data.name,
               url: input.data.url,
             },
           });

--- a/packages/app/src/systems/Network/services/network.ts
+++ b/packages/app/src/systems/Network/services/network.ts
@@ -24,6 +24,9 @@ export type NetworkInputs = {
   getNetworkByUrl: {
     url: string;
   };
+  getNetworkByName: {
+    name: string;
+  };
   getNetworkByNameOrUrl: {
     name: string;
     url: string;
@@ -87,6 +90,25 @@ export class NetworkService {
   static getNetworkByUrl(input: NetworkInputs['getNetworkByUrl']) {
     return db.transaction('r', db.networks, async () => {
       return db.networks.get({ url: input.url });
+    });
+  }
+
+  static getNetworkByName(input: NetworkInputs['getNetworkByName']) {
+    return db.transaction('r', db.networks, async () => {
+      return db.networks
+        .where('name')
+        .equalsIgnoreCase(input.name)
+        .first();
+    });
+  }
+
+  static async checkNetworkByName(input: NetworkInputs['getNetworkByName']) {
+    return db.transaction('r', db.networks, async () => {
+      const network = await db.networks
+        .where('name')
+        .equalsIgnoreCase(input.name)
+        .first();
+      return Boolean(network);
     });
   }
 
@@ -377,13 +399,12 @@ export class NetworkService {
   static async validateNetworkExists(
     input: NetworkInputs['validateNetworkExists']
   ) {
-    const { name, url } = input;
-    const network = await NetworkService.getNetworkByNameOrUrl({
-      name,
-      url,
+    const { url } = input;
+    const network = await NetworkService.getNetworkByUrl({
+      url
     });
     if (network) {
-      throw new Error('Network with Name or URL already exists');
+      throw new Error('Network URL already exists');
     }
   }
 


### PR DESCRIPTION
Modified the network addition logic in the Fuel wallet to focus on URL validation, omitting the name check for greater efficiency. Now, if a network name already exists, the creation date is appended to ensure uniqueness without rejection. This change streamlines the process, enhancing usability and reducing time spent on adding networks.