### PR TITLE
fix: wallet installation detection

### DIFF
--- a/.changeset/funny-melons-sniff.md
+++ b/.changeset/funny-melons-sniff.md
@@ -1,0 +1,5 @@
+---
+"@fuel-wallet/connections": patch
+---
+
+Fixed extension not being detected as installed after inactivity period.

--- a/.changeset/happy-clouds-hope.md
+++ b/.changeset/happy-clouds-hope.md
@@ -1,0 +1,5 @@
+---
+"fuels-wallet": patch
+---
+
+Avoid duplicating instances of injected Content Script

--- a/packages/app/src/systems/CRX/background/actions/onInstall.ts
+++ b/packages/app/src/systems/CRX/background/actions/onInstall.ts
@@ -17,6 +17,4 @@ chrome.runtime.onInstalled.addListener(async (object) => {
   ) {
     chrome.tabs.create({ url: welcomeLink() });
   }
-
-  executeContentScript();
 });

--- a/packages/app/src/systems/CRX/scripts/executeContentScript.ts
+++ b/packages/app/src/systems/CRX/scripts/executeContentScript.ts
@@ -7,9 +7,8 @@ import fileName from './contentScript?script';
  */
 export async function executeContentScript() {
   chrome.tabs.query({ url: '<all_urls>' }, (tabs) => {
-    // biome-ignore lint/complexity/noForEach: <explanation>
-    tabs.forEach((tab) => {
-      if (!tab.id) return;
+    for (const tab of tabs) {
+      if (!tab.id || tab.url?.startsWith('chrome://')) continue;
       chrome.scripting
         .executeScript({
           target: { tabId: tab.id, allFrames: true },
@@ -17,7 +16,9 @@ export async function executeContentScript() {
           injectImmediately: true,
         })
         // Ignore errors on tabs when executing script
-        .catch(() => {});
-    });
+        .catch((err) => {
+          console.warn(err);
+        });
+    }
   });
 }


### PR DESCRIPTION

Closes #1464 

# Changes

## @fuel-wallet/connections
- Fixed extension not being detected as installed after inactivity period.
- Fixed not being detected after fresh install on currently open tabs

## Wallet
- Avoid duplicating instances of injected Content Script
- Avoid attempting to inject into restricted urls (e.g. `chrome://...`)

# Evidence

## Before

[Fresh Install](https://github.com/user-attachments/assets/a22507b2-833f-4013-97b5-64685c53d259)
[Inactivity/Suspension](https://github.com/user-attachments/assets/4c88db00-88bd-43d6-8834-70f7b5853f61)

## After

[Fresh Install](https://github.com/user-attachments/assets/20b5c026-d523-4864-a391-b9c6385aeb85)
[Inactivity/Suspension](https://github.com/user-attachments/assets/92c22da0-db65-4a0b-8538-b40a3104a00e)


