### PR TITLE
fix: custom assets addition and id duplication

### DIFF
--- a/.changeset/nine-frogs-carry.md
+++ b/.changeset/nine-frogs-carry.md
@@ -1,0 +1,5 @@
+---
+"fuels-wallet": patch
+---
+
+Fixed not being able to add a known token on a different network

--- a/.changeset/rotten-plums-leave.md
+++ b/.changeset/rotten-plums-leave.md
@@ -1,0 +1,5 @@
+---
+"fuels-wallet": patch
+---
+
+Fixed being able to manually create custom assets with duplicate asset ids

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -53,7 +53,7 @@
     "react-hook-form": "7.47.0",
     "react-json-view": "1.21.3",
     "react-qr-code": "2.0.12",
-    "react-router-dom": "6.16.0",
+    "react-router-dom": "6.26.2",
     "tai64": "1.0.0",
     "vite-plugin-markdown": "2.2.0",
     "xstate": "4.38.2",

--- a/packages/app/playwright/commons/text.ts
+++ b/packages/app/playwright/commons/text.ts
@@ -15,6 +15,14 @@ export async function hasText(
   return textFound;
 }
 
+export async function hasNoText(
+  page: Page,
+  text: string | RegExp,
+  position = 0
+) {
+  return await expect(page.getByText(text).nth(position)).rejects.toThrow();
+}
+
 export async function hasAriaLabel(page: Page, value: string) {
   const selector = await page.waitForSelector(`[aria-label="${value}"]`);
   expect(await selector.getAttribute('aria-label')).toBe(value);

--- a/packages/app/playwright/crx/crx.test.ts
+++ b/packages/app/playwright/crx/crx.test.ts
@@ -588,6 +588,21 @@ test.describe('FuelWallet Extension', () => {
       await expect(addingAsset).resolves.toBeDefined();
     });
 
+    await test.step(' should not be able to add Assets with duplicate asset ids()', async () => {
+      function addAssets(assets: Asset[]) {
+        return blankPage.evaluate(
+          async ([asset]) => {
+            return window.fuel.addAssets(asset);
+          },
+          [assets]
+        );
+      }
+
+      await expect(async () =>
+        addAssets([CUSTOM_ASSET_INPUT, CUSTOM_ASSET_INPUT_2])
+      ).rejects.toThrow();
+    });
+
     await test.step('window.fuel.addNetwork()', async () => {
       function addNetwork(network: string) {
         return blankPage.evaluate(

--- a/packages/app/playwright/crx/crx.test.ts
+++ b/packages/app/playwright/crx/crx.test.ts
@@ -588,21 +588,6 @@ test.describe('FuelWallet Extension', () => {
       await expect(addingAsset).resolves.toBeDefined();
     });
 
-    await test.step(' should not be able to add Assets with duplicate asset ids()', async () => {
-      function addAssets(assets: Asset[]) {
-        return blankPage.evaluate(
-          async ([asset]) => {
-            return window.fuel.addAssets(asset);
-          },
-          [assets]
-        );
-      }
-
-      await expect(async () =>
-        addAssets([CUSTOM_ASSET_INPUT, CUSTOM_ASSET_INPUT_2])
-      ).rejects.toThrow();
-    });
-
     await test.step('window.fuel.addNetwork()', async () => {
       function addNetwork(network: string) {
         return blankPage.evaluate(

--- a/packages/app/playwright/e2e/Asset.test.ts
+++ b/packages/app/playwright/e2e/Asset.test.ts
@@ -1,7 +1,14 @@
 import type { Browser, Page } from '@playwright/test';
 import test, { chromium } from '@playwright/test';
 
-import { getByAriaLabel, hasText, reload, visit, waitUrl } from '../commons';
+import {
+  getByAriaLabel,
+  hasNoText,
+  hasText,
+  reload,
+  visit,
+  waitUrl,
+} from '../commons';
 import { CUSTOM_ASSET_SCREEN, mockData } from '../mocks';
 
 test.describe('Asset', () => {
@@ -37,5 +44,27 @@ test.describe('Asset', () => {
     await hasText(page, /Listed/i);
     await getByAriaLabel(page, 'Custom Assets').click();
     await hasText(page, CUSTOM_ASSET_SCREEN.name);
+  });
+
+  test('should not be able to add asset with duplicate asset id', async () => {
+    const randomName = 'RandomAsset';
+    await visit(page, '/assets');
+    await hasText(page, /Listed/i);
+    await getByAriaLabel(page, 'Add Asset').click();
+    await hasText(page, 'Save');
+    await getByAriaLabel(page, 'Asset ID').fill(CUSTOM_ASSET_SCREEN.assetId);
+    await getByAriaLabel(page, 'Asset name').fill(randomName);
+    await getByAriaLabel(page, 'Asset symbol').fill(randomName);
+    await getByAriaLabel(page, 'Asset decimals').fill(
+      String(CUSTOM_ASSET_SCREEN.decimals)
+    );
+    await getByAriaLabel(page, 'Asset image Url').fill(
+      CUSTOM_ASSET_SCREEN.icon
+    );
+    await getByAriaLabel(page, 'Save Asset').click();
+    await visit(page, '/assets');
+    await hasText(page, /Listed/i);
+    await getByAriaLabel(page, 'Custom Assets').click();
+    await hasNoText(page, randomName);
   });
 });

--- a/packages/app/playwright/e2e/Asset.test.ts
+++ b/packages/app/playwright/e2e/Asset.test.ts
@@ -97,6 +97,17 @@ test.describe('Asset', () => {
     await hasText(page, 'Asset name used as a symbol by listed asset');
   });
 
+  test('should not be able to add asset with symbol used as a name by other asset', async () => {
+    await goToAssetPage(page);
+    await getByAriaLabel(page, 'Asset ID').fill(
+      '0x599012155ae253353c7df01f36c8f6249c94131a69a3484bdb0234e3822b5100'
+    );
+    await getByAriaLabel(page, 'Asset name').fill('RAND');
+    await getByAriaLabel(page, 'Asset symbol').fill(CUSTOM_ASSET_SCREEN.name);
+    await getByAriaLabel(page, 'Save Asset').click();
+    await hasText(page, 'Asset symbol already used as a name by listed asset');
+  });
+
   test('should not be able to add asset with duplicate symbol', async () => {
     await goToAssetPage(page);
     await getByAriaLabel(page, 'Asset ID').fill(

--- a/packages/app/playwright/mocks/database.ts
+++ b/packages/app/playwright/mocks/database.ts
@@ -86,6 +86,21 @@ export const CUSTOM_ASSET_INPUT_3: Asset = {
   ],
 };
 
+export const CUSTOM_ASSET_INPUT_4: Asset = {
+  name: 'New3',
+  symbol: 'NEW3',
+  icon: 'https://upload.wikimedia.org/wikipedia/commons/thumb/4/46/Bitcoin.svg/1200px-Bitcoin.svg.png',
+  networks: [
+    {
+      type: 'fuel',
+      assetId:
+        '0x566012155ae253353c7df01f36c8f6249c94131a69a3484bdb0234e3822b5d20',
+      decimals: 2,
+      chainId: 0,
+    },
+  ],
+};
+
 export const CUSTOM_ASSET_SCREEN = {
   assetId: '0x566012155ae253353c7df01f36c8f6249c94131a69a3484bdb0234e3822b5d92',
   name: 'New',

--- a/packages/app/playwright/mocks/database.ts
+++ b/packages/app/playwright/mocks/database.ts
@@ -55,6 +55,7 @@ export const CUSTOM_ASSET_INPUT: Asset = {
     },
   ],
 };
+
 export const CUSTOM_ASSET_INPUT_2: Asset = {
   name: 'New1',
   symbol: 'NEW1',
@@ -70,8 +71,23 @@ export const CUSTOM_ASSET_INPUT_2: Asset = {
   ],
 };
 
+export const CUSTOM_ASSET_INPUT_3: Asset = {
+  name: 'New2',
+  symbol: 'NEW2',
+  icon: 'https://upload.wikimedia.org/wikipedia/commons/thumb/4/46/Bitcoin.svg/1200px-Bitcoin.svg.png',
+  networks: [
+    {
+      type: 'fuel',
+      assetId:
+        '0x566012155ae253353c7df01f36c8f6249c94131a69a3484bdb0234e3822b5d99',
+      decimals: 2,
+      chainId: 0,
+    },
+  ],
+};
+
 export const CUSTOM_ASSET_SCREEN = {
-  assetId: '0x566012155ae253353c7df01f36c8f6249c94131a69a3484bdb0234e3822b5d90',
+  assetId: '0x566012155ae253353c7df01f36c8f6249c94131a69a3484bdb0234e3822b5d92',
   name: 'New',
   symbol: 'NEW',
   icon: 'https://upload.wikimedia.org/wikipedia/commons/thumb/4/46/Bitcoin.svg/1200px-Bitcoin.svg.png',

--- a/packages/app/src/systems/Asset/services/assets.ts
+++ b/packages/app/src/systems/Asset/services/assets.ts
@@ -240,8 +240,6 @@ export class AssetService {
       existingAssetSymbolMap.set(asset.symbol, asset);
       for (const network of asset.networks) {
         if (network.type === 'fuel') {
-          if (assetIdChainMap.get(network.assetId))
-            throw new Error('Asset ID already exists');
           assetIdChainMap.set(network.assetId, network.chainId);
         } else if (network.address) {
           networkAddressChainMap.set(network.address, network.chainId);

--- a/packages/app/src/systems/Asset/services/assets.ts
+++ b/packages/app/src/systems/Asset/services/assets.ts
@@ -328,6 +328,7 @@ export class AssetService {
       const existingAsset =
         existingAssetNameMap.get(asset.name) ||
         existingAssetSymbolMap.get(asset.symbol);
+
       if (existingAsset?.isCustom) {
         AssetService.validateCustomAsset(
           {

--- a/packages/app/src/systems/Asset/services/assets.ts
+++ b/packages/app/src/systems/Asset/services/assets.ts
@@ -342,6 +342,11 @@ export class AssetService {
             symbol: asset.symbol,
           }
         );
+        customAssetsToAdd.push({
+          ...asset,
+          networks: [],
+          isCustom: true,
+        });
       }
 
       if (existingAsset && !existingAsset.isCustom) {

--- a/packages/app/src/systems/Asset/services/assets.ts
+++ b/packages/app/src/systems/Asset/services/assets.ts
@@ -348,6 +348,7 @@ export class AssetService {
           networks: [],
           isCustom: true,
         });
+        continue;
       }
 
       if (existingAsset && !existingAsset.isCustom) {

--- a/packages/app/src/systems/Asset/services/assets.ts
+++ b/packages/app/src/systems/Asset/services/assets.ts
@@ -392,6 +392,14 @@ export class AssetService {
 
           if (!isDuplicate) {
             nonDuplicateNetworks.push(newNetwork);
+            // Include new data in maps to check for duplication
+            if (newNetwork.type === 'fuel')
+              assetIdChainMap.set(newNetwork.assetId, newNetwork.chainId);
+            if (newNetwork.type === 'ethereum' && newNetwork.address)
+              networkAddressChainMap.set(
+                newNetwork.address,
+                newNetwork.chainId
+              );
           }
         }
 

--- a/packages/app/src/systems/Asset/services/assets.ts
+++ b/packages/app/src/systems/Asset/services/assets.ts
@@ -335,7 +335,23 @@ export class AssetService {
       const existingAsset =
         existingAssetNameMap.get(asset.name) ||
         existingAssetSymbolMap.get(asset.symbol);
-      if (existingAsset && !existingAsset.isCustom) {
+      if (existingAsset?.isCustom) {
+        AssetService.validateCustomAsset(
+          {
+            assetIdChainMap,
+            existingAssetNameMap,
+            existingAssetSymbolMap,
+          },
+          {
+            // biome-ignore lint/suspicious/noExplicitAny:  assetId: (asset as any)?.assetId as string,oming custom asset ids have assetId at the root
+            assetId: (asset as any)?.assetId as string,
+            name: asset.name,
+            symbol: asset.symbol,
+          }
+        );
+      }
+
+      if (existingAsset) {
         const nonDuplicateNetworks: Array<NetworkEthereum | NetworkFuel> = [];
 
         for (const newNetwork of asset.networks) {

--- a/packages/app/src/systems/Asset/services/assets.ts
+++ b/packages/app/src/systems/Asset/services/assets.ts
@@ -131,6 +131,14 @@ export class AssetService {
       throw new Error('Asset name already exists');
     }
 
+    if (existingAssetSymbolMap.get(input.data.name)) {
+      throw new Error('Asset name used as a symbol by listed asset');
+    }
+
+    if (existingAssetNameMap.get(input.data.symbol)) {
+      throw new Error('Asset symbol already used as a name by listed asset');
+    }
+
     if (existingAssetSymbolMap.get(input.data.symbol)) {
       throw new Error('Asset symbol already exists');
     }

--- a/packages/app/src/systems/Asset/services/assets.ts
+++ b/packages/app/src/systems/Asset/services/assets.ts
@@ -123,25 +123,14 @@ export class AssetService {
     const { existingAssetNameMap, existingAssetSymbolMap, assetIdChainMap } =
       await AssetService.mapAssetsByAddressAndAssetId(assets);
 
-    if (assetIdChainMap.get(input.data.assetId) !== undefined) {
-      throw new Error('Asset ID already exists');
-    }
-
-    if (existingAssetNameMap.get(input.data.name)) {
-      throw new Error('Asset name already exists');
-    }
-
-    if (existingAssetSymbolMap.get(input.data.name)) {
-      throw new Error('Asset name used as a symbol by listed asset');
-    }
-
-    if (existingAssetNameMap.get(input.data.symbol)) {
-      throw new Error('Asset symbol already used as a name by listed asset');
-    }
-
-    if (existingAssetSymbolMap.get(input.data.symbol)) {
-      throw new Error('Asset symbol already exists');
-    }
+    AssetService.validateCustomAsset(
+      {
+        assetIdChainMap,
+        existingAssetNameMap,
+        existingAssetSymbolMap,
+      },
+      input.data
+    );
 
     const currentFuelAsset = await getFuelAssetByAssetId({
       assets,
@@ -179,6 +168,41 @@ export class AssetService {
     });
   }
 
+  static validateCustomAsset(
+    {
+      assetIdChainMap,
+      existingAssetNameMap,
+      existingAssetSymbolMap,
+    }: Omit<
+      Awaited<ReturnType<typeof AssetService.mapAssetsByAddressAndAssetId>>,
+      'networkAddressChainMap'
+    >,
+    assetData: {
+      assetId: string;
+      name: string;
+      symbol: string;
+    }
+  ) {
+    if (assetIdChainMap.get(assetData.assetId) !== undefined) {
+      throw new Error('Asset ID already exists');
+    }
+
+    if (existingAssetNameMap.get(assetData.name)) {
+      throw new Error('Asset name already exists');
+    }
+
+    if (existingAssetSymbolMap.get(assetData.name)) {
+      throw new Error('Asset name used as a symbol by listed asset');
+    }
+
+    if (existingAssetNameMap.get(assetData.symbol)) {
+      throw new Error('Asset symbol already used as a name by listed asset');
+    }
+
+    if (existingAssetSymbolMap.get(assetData.symbol)) {
+      throw new Error('Asset symbol already exists');
+    }
+  }
   static async addAssets(input: AssetInputs['addAssets']) {
     return db.transaction('rw', db.assets, async () => {
       await db.assets.bulkAdd(input.data);

--- a/packages/app/src/systems/Asset/services/assets.ts
+++ b/packages/app/src/systems/Asset/services/assets.ts
@@ -344,7 +344,7 @@ export class AssetService {
         );
       }
 
-      if (existingAsset) {
+      if (existingAsset && !existingAsset.isCustom) {
         const nonDuplicateNetworks: Array<NetworkEthereum | NetworkFuel> = [];
 
         for (const newNetwork of asset.networks) {

--- a/packages/app/src/systems/Asset/services/assets.ts
+++ b/packages/app/src/systems/Asset/services/assets.ts
@@ -261,7 +261,10 @@ export class AssetService {
       existingAssetMap.set(asset.name, asset);
     }
 
-    const assetsToAdd: AssetData[] = [];
+    const newAssetsToAdd: AssetData[] = [];
+    // Assets that exist but in different chains
+    const customAssetsToAdd: AssetData[] = [];
+
     for (const asset of trimmedAssets) {
       const existingAsset = existingAssetMap.get(asset.name);
       if (existingAsset && !existingAsset.isCustom) {
@@ -297,16 +300,17 @@ export class AssetService {
           );
         }
 
-        assetsToAdd.push({
+        customAssetsToAdd.push({
           ...asset,
           networks: nonDuplicateNetworks,
+          isCustom: true,
         });
       } else {
-        assetsToAdd.push(asset);
+        newAssetsToAdd.push(asset);
       }
     }
 
-    return { assetsToAdd };
+    return newAssetsToAdd.concat(customAssetsToAdd);
   }
 
   static async avoidRepeatedFields(assets: AssetData[]) {

--- a/packages/app/src/systems/Asset/services/assets.ts
+++ b/packages/app/src/systems/Asset/services/assets.ts
@@ -1,12 +1,5 @@
-import { createProvider } from '@fuel-wallet/connections';
 import type { AssetData, AssetFuelData } from '@fuel-wallet/types';
-import {
-  type NetworkEthereum,
-  type NetworkFuel,
-  assets,
-  getAssetFuel,
-} from 'fuels';
-import { type Provider, isB256 } from 'fuels';
+import { type NetworkEthereum, type NetworkFuel, assets } from 'fuels';
 import { db } from '~/systems/Core/utils/database';
 import { getUniqueString } from '~/systems/Core/utils/string';
 import { NetworkService } from '~/systems/Network/services/network';
@@ -264,7 +257,7 @@ export class AssetService {
     const networkAddressChainMap = new Map<string, number>();
     for (const asset of existingAssets) {
       // @TODO: Remove this when we have a better way to handle this
-      // biome-ignore lint/suspicious/noExplicitAny: Sometimes a assetId comes at the root of the asset
+      // biome-ignore lint/suspicious/noExplicitAny: Incoming custom asset ids have the assetId at the root
       const looseAssetId = (asset as any)?.assetId as string | undefined;
       looseAssetId && assetIdChainMap.set(looseAssetId, 0);
 
@@ -343,7 +336,7 @@ export class AssetService {
             existingAssetSymbolMap,
           },
           {
-            // biome-ignore lint/suspicious/noExplicitAny:  assetId: (asset as any)?.assetId as string,oming custom asset ids have assetId at the root
+            // biome-ignore lint/suspicious/noExplicitAny: Incoming custom asset ids have assetId at the root
             assetId: (asset as any)?.assetId as string,
             name: asset.name,
             symbol: asset.symbol,

--- a/packages/app/src/systems/CRX/background/services/BackgroundService.ts
+++ b/packages/app/src/systems/CRX/background/services/BackgroundService.ts
@@ -371,11 +371,15 @@ export class BackgroundService {
     input: MessageInputs['addAssets'],
     serverParams: EventOrigin
   ) {
-    const { assetsToAdd } = await AssetService.validateAddAssets(input.assets);
+    const assetsToAdd = await AssetService.validateAddAssets(input.assets);
 
     const origin = serverParams.origin;
     const title = serverParams.title;
     const favIconUrl = serverParams.favIconUrl;
+
+    if (!assetsToAdd?.length) {
+      throw new Error('No assets to add');
+    }
 
     const popupService = await PopUpService.open(
       origin,

--- a/packages/app/src/systems/Core/types.ts
+++ b/packages/app/src/systems/Core/types.ts
@@ -42,7 +42,7 @@ export const Pages = {
   logout: route('/accounts/logout'),
   assets: route('/assets'),
   assetsEdit: route<'name'>('/assets/edit/:name'),
-  assetsAdd: route<'assetId'>('/assets/add/:assetId'),
+  assetsAdd: route<'assetId'>('/assets/add/:assetId?'),
   errors: route('/errors'),
 };
 

--- a/packages/app/src/systems/Core/utils/route.test.ts
+++ b/packages/app/src/systems/Core/utils/route.test.ts
@@ -2,12 +2,37 @@ import { route } from './route';
 
 describe('route()', () => {
   it('should parse a route based on params', () => {
-    const user = route<'id'>('/user/:id');
+    const routePath = '/user/:id';
+    const user = route<'id'>(routePath);
+    // Should return complete path regardless of params on the first run
+    expect(`${user({ id: 1 })}`).toBe(routePath);
+
     expect(`${user({ id: 1 })}`).toBe('/user/1');
   });
 
-  it('should parse a query string', () => {
-    const user = route<'id'>('/user/:id');
-    expect(`${user({ id: 1 }, { page: 1 })}`).toBe('/user/1?page=1');
+  it('should parse optional params when not provided', () => {
+    const routePath = '/asset/:assetId?';
+    const asset = route<'assetId'>(routePath);
+    // Should return complete path regardless of params on the first run
+    expect(`${asset()}`).toBe(routePath);
+
+    // Should return complete path regardless of params on the first run
+    expect(`${asset()}`).toBe('/asset/');
+  });
+  it('should parse optional params when provided', () => {
+    const routePath = '/asset/:assetId?';
+    const asset = route<'assetId'>(routePath);
+    // Should return complete path regardless of params on the first run
+    expect(`${asset({ assetId: '1' })}`).toBe(routePath);
+
+    expect(`${asset({ assetId: '1' })}`).toBe('/asset/1');
+  });
+  it('should throw when required param is not provided', () => {
+    const routePath = '/asset/:assetId';
+    const asset = route<'assetId'>(routePath);
+    // Should return complete path regardless of params on the first run
+    expect(`${asset({ assetId: 'x' })}`).toBe(routePath);
+
+    expect(() => asset()).toThrow();
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,7 +96,7 @@ importers:
         version: 3.0.0
       jest:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@20.8.4)(ts-node@10.9.1(@swc/core@1.3.92)(@types/node@20.8.4)(typescript@5.2.2))
+        version: 29.7.0(@types/node@20.8.4)(ts-node@10.9.1(@swc/core@1.3.92(@swc/helpers@0.5.11))(@types/node@20.8.4)(typescript@5.2.2))
       jest-environment-jsdom:
         specifier: 29.7.0
         version: 29.7.0(bufferutil@4.0.8)(utf-8-validate@6.0.4)
@@ -111,10 +111,10 @@ importers:
         version: 4.1.5
       ts-jest:
         specifier: ^29.1.1
-        version: 29.1.1(@babel/core@7.23.2)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.23.2))(jest@29.7.0(@types/node@20.8.4)(ts-node@10.9.1(@swc/core@1.3.92)(@types/node@20.8.4)(typescript@5.2.2)))(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.23.2)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.23.2))(jest@29.7.0(@types/node@20.8.4)(ts-node@10.9.1(@swc/core@1.3.92(@swc/helpers@0.5.11))(@types/node@20.8.4)(typescript@5.2.2)))(typescript@5.2.2)
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.1(@swc/core@1.3.92)(@types/node@20.8.4)(typescript@5.2.2)
+        version: 10.9.1(@swc/core@1.3.92(@swc/helpers@0.5.11))(@types/node@20.8.4)(typescript@5.2.2)
       turbo:
         specifier: ^1.10.15
         version: 1.10.15
@@ -181,7 +181,7 @@ importers:
         version: 0.23.3(@fuel-ui/css@0.23.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@fuel-ui/icons@0.23.3)(@types/react-dom@18.3.0)(@types/react@18.3.3)(fuels@0.0.0-pr-3167-20240915223932)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@fuel-ui/test-utils':
         specifier: 0.17.0
-        version: 0.17.0(@babel/core@7.24.0)(@jest/types@29.6.3)(@types/node@20.12.11)(babel-jest@29.7.0(@babel/core@7.24.0))(bufferutil@4.0.8)(esbuild@0.18.20)(react@18.3.1)(ts-node@10.9.1(@swc/core@1.3.92)(@types/node@20.8.4)(typescript@5.2.2))(typescript@5.2.2)(utf-8-validate@5.0.10)
+        version: 0.17.0(@babel/core@7.24.0)(@jest/types@29.6.3)(@types/node@20.12.11)(babel-jest@29.7.0(@babel/core@7.24.0))(bufferutil@4.0.8)(esbuild@0.18.20)(react@18.3.1)(ts-node@10.9.1(@swc/core@1.3.92(@swc/helpers@0.5.11))(@types/node@20.8.4)(typescript@5.2.2))(typescript@5.2.2)(utf-8-validate@5.0.10)
       '@fuel-wallet/connections':
         specifier: workspace:*
         version: link:../connections
@@ -208,7 +208,7 @@ importers:
         version: 7.4.6(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@storybook/jest':
         specifier: 0.2.3
-        version: 0.2.3(@jest/globals@29.7.0)(jest@29.7.0(@types/node@20.12.11)(ts-node@10.9.1(@swc/core@1.3.92)(@types/node@20.8.4)(typescript@5.2.2)))
+        version: 0.2.3(@jest/globals@29.7.0)(jest@29.7.0(@types/node@20.12.11)(ts-node@10.9.1(@swc/core@1.3.92(@swc/helpers@0.5.11))(@types/node@20.8.4)(typescript@5.2.2)))
       '@tanstack/react-query':
         specifier: 5.28.4
         version: 5.28.4(react@18.3.1)
@@ -270,8 +270,8 @@ importers:
         specifier: 2.0.12
         version: 2.0.12(react@18.3.1)
       react-router-dom:
-        specifier: 6.16.0
-        version: 6.16.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 6.26.2
+        version: 6.26.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       tai64:
         specifier: 1.0.0
         version: 1.0.0
@@ -392,13 +392,13 @@ importers:
         version: 7.4.6(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       storybook-addon-react-router-v6:
         specifier: 2.0.7
-        version: 2.0.7(@storybook/blocks@7.4.6(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@storybook/channels@7.4.6)(@storybook/components@7.4.6(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@storybook/core-events@7.4.6)(@storybook/manager-api@7.4.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@storybook/preview-api@7.4.6)(@storybook/theming@7.4.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react-router-dom@6.16.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+        version: 2.0.7(@storybook/blocks@7.4.6(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@storybook/channels@7.4.6)(@storybook/components@7.4.6(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@storybook/core-events@7.4.6)(@storybook/manager-api@7.4.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@storybook/preview-api@7.4.6)(@storybook/theming@7.4.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react-router-dom@6.26.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       storybook-dark-mode:
         specifier: 3.0.1
         version: 3.0.1(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       ts-jest-mock-import-meta:
         specifier: 1.1.0
-        version: 1.1.0(ts-jest@29.1.2(@babel/core@7.24.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.0))(esbuild@0.18.20)(jest@29.7.0(@types/node@20.12.11)(ts-node@10.9.1(@swc/core@1.3.92)(@types/node@20.8.4)(typescript@5.2.2)))(typescript@5.2.2))
+        version: 1.1.0(ts-jest@29.1.2(@babel/core@7.24.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.0))(esbuild@0.18.20)(jest@29.7.0(@types/node@20.12.11)(ts-node@10.9.1(@swc/core@1.3.92(@swc/helpers@0.5.11))(@types/node@20.8.4)(typescript@5.2.2)))(typescript@5.2.2))
       tsconfig-paths-webpack-plugin:
         specifier: 4.1.0
         version: 4.1.0
@@ -456,7 +456,7 @@ importers:
         version: 29.6.2(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       tsup:
         specifier: ^7.2.0
-        version: 7.2.0(@swc/core@1.3.92)(postcss@8.4.41)(ts-node@10.9.1(@swc/core@1.3.92)(@types/node@20.8.4)(typescript@5.2.2))(typescript@5.2.2)
+        version: 7.2.0(@swc/core@1.3.92(@swc/helpers@0.5.11))(postcss@8.4.41)(ts-node@10.9.1(@swc/core@1.3.92(@swc/helpers@0.5.11))(@types/node@20.12.11)(typescript@5.2.2))(typescript@5.2.2)
       undici:
         specifier: ^6.4.0
         version: 6.16.1
@@ -604,7 +604,7 @@ importers:
         version: 15.5.8
       next-images:
         specifier: 1.8.5
-        version: 1.8.5(webpack@5.91.0(@swc/core@1.3.92))
+        version: 1.8.5(webpack@5.91.0(@swc/core@1.3.92(@swc/helpers@0.5.11)))
       prettier:
         specifier: 2.8.8
         version: 2.8.8
@@ -693,7 +693,7 @@ importers:
         version: 0.23.0(typescript@5.2.2)
       '@fuels/tsup-config':
         specifier: ^0.23.0
-        version: 0.23.0(tsup@7.2.0(@swc/core@1.3.92)(postcss@8.4.41)(ts-node@10.9.1(@swc/core@1.3.92)(@types/node@20.8.4)(typescript@5.2.2))(typescript@5.2.2))
+        version: 0.23.0(tsup@7.2.0(@swc/core@1.3.92(@swc/helpers@0.5.11))(postcss@8.4.41)(ts-node@10.9.1(@swc/core@1.3.92(@swc/helpers@0.5.11))(@types/node@20.12.11)(typescript@5.2.2))(typescript@5.2.2))
       '@playwright/test':
         specifier: ^1.39.0
         version: 1.46.1
@@ -705,7 +705,7 @@ importers:
         version: 0.0.0-pr-3167-20240915223932
       tsup:
         specifier: ^7.2.0
-        version: 7.2.0(@swc/core@1.3.92)(postcss@8.4.41)(ts-node@10.9.1(@swc/core@1.3.92)(@types/node@20.8.4)(typescript@5.2.2))(typescript@5.2.2)
+        version: 7.2.0(@swc/core@1.3.92(@swc/helpers@0.5.11))(postcss@8.4.41)(ts-node@10.9.1(@swc/core@1.3.92(@swc/helpers@0.5.11))(@types/node@20.12.11)(typescript@5.2.2))(typescript@5.2.2)
 
   packages/types:
     dependencies:
@@ -721,7 +721,7 @@ importers:
         version: 0.0.0-pr-3167-20240915223932
       tsup:
         specifier: ^7.2.0
-        version: 7.2.0(@swc/core@1.3.92)(postcss@8.4.41)(ts-node@10.9.1(@swc/core@1.3.92)(@types/node@20.8.4)(typescript@5.2.2))(typescript@5.2.2)
+        version: 7.2.0(@swc/core@1.3.92(@swc/helpers@0.5.11))(postcss@8.4.41)(ts-node@10.9.1(@swc/core@1.3.92(@swc/helpers@0.5.11))(@types/node@20.12.11)(typescript@5.2.2))(typescript@5.2.2)
 
 packages:
 
@@ -3292,8 +3292,8 @@ packages:
     resolution: {integrity: sha512-ZT8e4BrcWrm44apLb412WR0fDsgeaS8UlI1c0wKRUPu1w/UntpXuUVO+EaY8WDlnOPAiAsjyqWKey64/DfvbXQ==}
     peerDependencies:
       '@react-native-async-storage/async-storage': ^1.19.6
-      react: '*'
-      react-dom: '*'
+      react: ^18.2.0
+      react-dom: ^18.2.0
       react-native: '*'
     peerDependenciesMeta:
       '@react-native-async-storage/async-storage':
@@ -4706,8 +4706,8 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
 
-  '@remix-run/router@1.9.0':
-    resolution: {integrity: sha512-bV63itrKBC0zdT27qYm6SDZHlkXwFL1xMBuhkn+X7l0+IIhNaH5wuuvZKp6eKhCD4KFhujhfhCT1YxXW6esUIA==}
+  '@remix-run/router@1.19.2':
+    resolution: {integrity: sha512-baiMx18+IMuD1yyvOGaHM9QrVUPGGG0jC+z+IPHnRJWUAUvaKuWKyE8gjDj2rzv3sz9zOGoRSPgeBVHRhZnBlA==}
     engines: {node: '>=14.0.0'}
 
   '@rnx-kit/chromium-edge-launcher@1.0.0':
@@ -11425,15 +11425,15 @@ packages:
       react: ^16.0.0 || ^17.0.0 || ^18.0.0
       react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0
 
-  react-router-dom@6.16.0:
-    resolution: {integrity: sha512-aTfBLv3mk/gaKLxgRDUPbPw+s4Y/O+ma3rEN1u8EgEpLpPe6gNjIsWt9rxushMHHMb7mSwxRGdGlGdvmFsyPIg==}
+  react-router-dom@6.26.2:
+    resolution: {integrity: sha512-z7YkaEW0Dy35T3/QKPYB1LjMK2R1fxnHO8kWpUMTBdfVzZrWOiY9a7CtN8HqdWtDUWd5FY6Dl8HFsqVwH4uOtQ==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       react: '>=16.8'
       react-dom: '>=16.8'
 
-  react-router@6.16.0:
-    resolution: {integrity: sha512-VT4Mmc4jj5YyjpOi5jOf0I+TYzGpvzERy4ckNSvSh2RArv8LLoCxlsZ2D+tc7zgjxcY34oTz2hZaeX5RVprKqA==}
+  react-router@6.26.2:
+    resolution: {integrity: sha512-tvN1iuT03kHgOFnLPfLJ8V95eijteveqdOSk+srqfePtQvqCExB8eHOYnlilbOcyJyKnYkr1vJvf7YqotAJu1A==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       react: '>=16.8'
@@ -18054,14 +18054,14 @@ snapshots:
       - csstype
       - immer
 
-  '@fuel-ui/test-utils@0.17.0(@babel/core@7.24.0)(@jest/types@29.6.3)(@types/node@20.12.11)(babel-jest@29.7.0(@babel/core@7.24.0))(bufferutil@4.0.8)(esbuild@0.18.20)(react@18.3.1)(ts-node@10.9.1(@swc/core@1.3.92)(@types/node@20.8.4)(typescript@5.2.2))(typescript@5.2.2)(utf-8-validate@5.0.10)':
+  '@fuel-ui/test-utils@0.17.0(@babel/core@7.24.0)(@jest/types@29.6.3)(@types/node@20.12.11)(babel-jest@29.7.0(@babel/core@7.24.0))(bufferutil@4.0.8)(esbuild@0.18.20)(react@18.3.1)(ts-node@10.9.1(@swc/core@1.3.92(@swc/helpers@0.5.11))(@types/node@20.8.4)(typescript@5.2.2))(typescript@5.2.2)(utf-8-validate@5.0.10)':
     dependencies:
       '@testing-library/dom': 9.3.1
       '@testing-library/jest-dom': 5.17.0
       '@testing-library/react': 14.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@testing-library/user-event': 14.4.3(@testing-library/dom@9.3.1)
       identity-obj-proxy: 3.0.0
-      jest: 29.7.0(@types/node@20.12.11)(ts-node@10.9.1(@swc/core@1.3.92)(@types/node@20.8.4)(typescript@5.2.2))
+      jest: 29.7.0(@types/node@20.12.11)(ts-node@10.9.1(@swc/core@1.3.92(@swc/helpers@0.5.11))(@types/node@20.8.4)(typescript@5.2.2))
       jest-axe: 7.0.1
       jest-environment-jsdom: 29.7.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       jest-fail-on-console: 3.1.1
@@ -18070,7 +18070,7 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       resize-observer-polyfill: 1.5.1
-      ts-jest: 29.1.1(@babel/core@7.24.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.0))(esbuild@0.18.20)(jest@29.7.0(@types/node@20.12.11)(ts-node@10.9.1(@swc/core@1.3.92)(@types/node@20.8.4)(typescript@5.2.2)))(typescript@5.2.2)
+      ts-jest: 29.1.1(@babel/core@7.24.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.0))(esbuild@0.18.20)(jest@29.7.0(@types/node@20.12.11)(ts-node@10.9.1(@swc/core@1.3.92(@swc/helpers@0.5.11))(@types/node@20.8.4)(typescript@5.2.2)))(typescript@5.2.2)
     transitivePeerDependencies:
       - '@babel/core'
       - '@jest/types'
@@ -18350,12 +18350,12 @@ snapshots:
     dependencies:
       typescript: 5.2.2
 
-  '@fuels/tsup-config@0.23.0(tsup@7.2.0(@swc/core@1.3.92)(postcss@8.4.41)(ts-node@10.9.1(@swc/core@1.3.92)(@types/node@20.8.4)(typescript@5.2.2))(typescript@5.2.2))':
+  '@fuels/tsup-config@0.23.0(tsup@7.2.0(@swc/core@1.3.92(@swc/helpers@0.5.11))(postcss@8.4.41)(ts-node@10.9.1(@swc/core@1.3.92(@swc/helpers@0.5.11))(@types/node@20.12.11)(typescript@5.2.2))(typescript@5.2.2))':
     dependencies:
       dotenv: 16.3.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      tsup: 7.2.0(@swc/core@1.3.92)(postcss@8.4.41)(ts-node@10.9.1(@swc/core@1.3.92)(@types/node@20.8.4)(typescript@5.2.2))(typescript@5.2.2)
+      tsup: 7.2.0(@swc/core@1.3.92(@swc/helpers@0.5.11))(postcss@8.4.41)(ts-node@10.9.1(@swc/core@1.3.92(@swc/helpers@0.5.11))(@types/node@20.12.11)(typescript@5.2.2))(typescript@5.2.2)
 
   '@fuels/vm-asm@0.56.0': {}
 
@@ -18432,7 +18432,7 @@ snapshots:
       jest-util: 29.7.0
       slash: 3.0.0
 
-  '@jest/core@29.7.0(ts-node@10.9.1(@swc/core@1.3.92)(@types/node@20.8.4)(typescript@5.2.2))':
+  '@jest/core@29.7.0(ts-node@10.9.1(@swc/core@1.3.92(@swc/helpers@0.5.11))(@types/node@20.8.4)(typescript@5.2.2))':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
@@ -18446,7 +18446,7 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.12.11)(ts-node@10.9.1(@swc/core@1.3.92)(@types/node@20.8.4)(typescript@5.2.2))
+      jest-config: 29.7.0(@types/node@20.12.11)(ts-node@10.9.1(@swc/core@1.3.92(@swc/helpers@0.5.11))(@types/node@20.8.4)(typescript@5.2.2))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -21529,7 +21529,7 @@ snapshots:
       '@react-types/shared': 3.21.0(react@18.3.1)
       react: 18.3.1
 
-  '@remix-run/router@1.9.0': {}
+  '@remix-run/router@1.19.2': {}
 
   '@rnx-kit/chromium-edge-launcher@1.0.0':
     dependencies:
@@ -22692,10 +22692,10 @@ snapshots:
       '@storybook/global': 5.0.0
       '@storybook/preview-api': 7.4.6
 
-  '@storybook/jest@0.2.3(@jest/globals@29.7.0)(jest@29.7.0(@types/node@20.12.11)(ts-node@10.9.1(@swc/core@1.3.92)(@types/node@20.8.4)(typescript@5.2.2)))':
+  '@storybook/jest@0.2.3(@jest/globals@29.7.0)(jest@29.7.0(@types/node@20.12.11)(ts-node@10.9.1(@swc/core@1.3.92(@swc/helpers@0.5.11))(@types/node@20.8.4)(typescript@5.2.2)))':
     dependencies:
       '@storybook/expect': 28.1.3-5
-      '@testing-library/jest-dom': 6.1.4(@jest/globals@29.7.0)(@types/jest@28.1.3)(jest@29.7.0(@types/node@20.12.11)(ts-node@10.9.1(@swc/core@1.3.92)(@types/node@20.8.4)(typescript@5.2.2)))
+      '@testing-library/jest-dom': 6.1.4(@jest/globals@29.7.0)(@types/jest@28.1.3)(jest@29.7.0(@types/node@20.12.11)(ts-node@10.9.1(@swc/core@1.3.92(@swc/helpers@0.5.11))(@types/node@20.8.4)(typescript@5.2.2)))
       '@types/jest': 28.1.3
       jest-mock: 27.5.1
     transitivePeerDependencies:
@@ -23149,7 +23149,7 @@ snapshots:
       lodash: 4.17.21
       redent: 3.0.0
 
-  '@testing-library/jest-dom@6.1.4(@jest/globals@29.7.0)(@types/jest@28.1.3)(jest@29.7.0(@types/node@20.12.11)(ts-node@10.9.1(@swc/core@1.3.92)(@types/node@20.8.4)(typescript@5.2.2)))':
+  '@testing-library/jest-dom@6.1.4(@jest/globals@29.7.0)(@types/jest@28.1.3)(jest@29.7.0(@types/node@20.12.11)(ts-node@10.9.1(@swc/core@1.3.92(@swc/helpers@0.5.11))(@types/node@20.8.4)(typescript@5.2.2)))':
     dependencies:
       '@adobe/css-tools': 4.3.2
       '@babel/runtime': 7.25.0
@@ -23162,7 +23162,7 @@ snapshots:
     optionalDependencies:
       '@jest/globals': 29.7.0
       '@types/jest': 28.1.3
-      jest: 29.7.0(@types/node@20.12.11)(ts-node@10.9.1(@swc/core@1.3.92)(@types/node@20.8.4)(typescript@5.2.2))
+      jest: 29.7.0(@types/node@20.12.11)(ts-node@10.9.1(@swc/core@1.3.92(@swc/helpers@0.5.11))(@types/node@20.8.4)(typescript@5.2.2))
 
   '@testing-library/react@14.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -26296,13 +26296,13 @@ snapshots:
 
   crc-32@1.2.2: {}
 
-  create-jest@29.7.0(@types/node@20.12.11)(ts-node@10.9.1(@swc/core@1.3.92)(@types/node@20.8.4)(typescript@5.2.2)):
+  create-jest@29.7.0(@types/node@20.12.11)(ts-node@10.9.1(@swc/core@1.3.92(@swc/helpers@0.5.11))(@types/node@20.8.4)(typescript@5.2.2)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@20.12.11)(ts-node@10.9.1(@swc/core@1.3.92)(@types/node@20.8.4)(typescript@5.2.2))
+      jest-config: 29.7.0(@types/node@20.12.11)(ts-node@10.9.1(@swc/core@1.3.92(@swc/helpers@0.5.11))(@types/node@20.8.4)(typescript@5.2.2))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -26311,13 +26311,13 @@ snapshots:
       - supports-color
       - ts-node
 
-  create-jest@29.7.0(@types/node@20.8.4)(ts-node@10.9.1(@swc/core@1.3.92)(@types/node@20.8.4)(typescript@5.2.2)):
+  create-jest@29.7.0(@types/node@20.8.4)(ts-node@10.9.1(@swc/core@1.3.92(@swc/helpers@0.5.11))(@types/node@20.8.4)(typescript@5.2.2)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@20.8.4)(ts-node@10.9.1(@swc/core@1.3.92)(@types/node@20.8.4)(typescript@5.2.2))
+      jest-config: 29.7.0(@types/node@20.8.4)(ts-node@10.9.1(@swc/core@1.3.92(@swc/helpers@0.5.11))(@types/node@20.8.4)(typescript@5.2.2))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -27369,11 +27369,11 @@ snapshots:
     dependencies:
       flat-cache: 3.0.4
 
-  file-loader@6.2.0(webpack@5.91.0(@swc/core@1.3.92)):
+  file-loader@6.2.0(webpack@5.91.0(@swc/core@1.3.92(@swc/helpers@0.5.11))):
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.91.0(@swc/core@1.3.92)
+      webpack: 5.91.0(@swc/core@1.3.92(@swc/helpers@0.5.11))
 
   file-system-cache@2.3.0:
     dependencies:
@@ -28545,16 +28545,16 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@20.12.11)(ts-node@10.9.1(@swc/core@1.3.92)(@types/node@20.8.4)(typescript@5.2.2)):
+  jest-cli@29.7.0(@types/node@20.12.11)(ts-node@10.9.1(@swc/core@1.3.92(@swc/helpers@0.5.11))(@types/node@20.8.4)(typescript@5.2.2)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.1(@swc/core@1.3.92)(@types/node@20.8.4)(typescript@5.2.2))
+      '@jest/core': 29.7.0(ts-node@10.9.1(@swc/core@1.3.92(@swc/helpers@0.5.11))(@types/node@20.8.4)(typescript@5.2.2))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@20.12.11)(ts-node@10.9.1(@swc/core@1.3.92)(@types/node@20.8.4)(typescript@5.2.2))
+      create-jest: 29.7.0(@types/node@20.12.11)(ts-node@10.9.1(@swc/core@1.3.92(@swc/helpers@0.5.11))(@types/node@20.8.4)(typescript@5.2.2))
       exit: 0.1.2
       import-local: 3.1.0
-      jest-config: 29.7.0(@types/node@20.12.11)(ts-node@10.9.1(@swc/core@1.3.92)(@types/node@20.8.4)(typescript@5.2.2))
+      jest-config: 29.7.0(@types/node@20.12.11)(ts-node@10.9.1(@swc/core@1.3.92(@swc/helpers@0.5.11))(@types/node@20.8.4)(typescript@5.2.2))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -28564,16 +28564,16 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@29.7.0(@types/node@20.8.4)(ts-node@10.9.1(@swc/core@1.3.92)(@types/node@20.8.4)(typescript@5.2.2)):
+  jest-cli@29.7.0(@types/node@20.8.4)(ts-node@10.9.1(@swc/core@1.3.92(@swc/helpers@0.5.11))(@types/node@20.8.4)(typescript@5.2.2)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.1(@swc/core@1.3.92)(@types/node@20.8.4)(typescript@5.2.2))
+      '@jest/core': 29.7.0(ts-node@10.9.1(@swc/core@1.3.92(@swc/helpers@0.5.11))(@types/node@20.8.4)(typescript@5.2.2))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@20.8.4)(ts-node@10.9.1(@swc/core@1.3.92)(@types/node@20.8.4)(typescript@5.2.2))
+      create-jest: 29.7.0(@types/node@20.8.4)(ts-node@10.9.1(@swc/core@1.3.92(@swc/helpers@0.5.11))(@types/node@20.8.4)(typescript@5.2.2))
       exit: 0.1.2
       import-local: 3.1.0
-      jest-config: 29.7.0(@types/node@20.8.4)(ts-node@10.9.1(@swc/core@1.3.92)(@types/node@20.8.4)(typescript@5.2.2))
+      jest-config: 29.7.0(@types/node@20.8.4)(ts-node@10.9.1(@swc/core@1.3.92(@swc/helpers@0.5.11))(@types/node@20.8.4)(typescript@5.2.2))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -28583,7 +28583,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@29.7.0(@types/node@20.12.11)(ts-node@10.9.1(@swc/core@1.3.92)(@types/node@20.8.4)(typescript@5.2.2)):
+  jest-config@29.7.0(@types/node@20.12.11)(ts-node@10.9.1(@swc/core@1.3.92(@swc/helpers@0.5.11))(@types/node@20.8.4)(typescript@5.2.2)):
     dependencies:
       '@babel/core': 7.24.0
       '@jest/test-sequencer': 29.7.0
@@ -28609,12 +28609,12 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 20.12.11
-      ts-node: 10.9.1(@swc/core@1.3.92)(@types/node@20.8.4)(typescript@5.2.2)
+      ts-node: 10.9.1(@swc/core@1.3.92(@swc/helpers@0.5.11))(@types/node@20.8.4)(typescript@5.2.2)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@29.7.0(@types/node@20.8.4)(ts-node@10.9.1(@swc/core@1.3.92)(@types/node@20.8.4)(typescript@5.2.2)):
+  jest-config@29.7.0(@types/node@20.8.4)(ts-node@10.9.1(@swc/core@1.3.92(@swc/helpers@0.5.11))(@types/node@20.8.4)(typescript@5.2.2)):
     dependencies:
       '@babel/core': 7.24.0
       '@jest/test-sequencer': 29.7.0
@@ -28640,7 +28640,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 20.8.4
-      ts-node: 10.9.1(@swc/core@1.3.92)(@types/node@20.8.4)(typescript@5.2.2)
+      ts-node: 10.9.1(@swc/core@1.3.92(@swc/helpers@0.5.11))(@types/node@20.8.4)(typescript@5.2.2)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -28970,24 +28970,24 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0(@types/node@20.12.11)(ts-node@10.9.1(@swc/core@1.3.92)(@types/node@20.8.4)(typescript@5.2.2)):
+  jest@29.7.0(@types/node@20.12.11)(ts-node@10.9.1(@swc/core@1.3.92(@swc/helpers@0.5.11))(@types/node@20.8.4)(typescript@5.2.2)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.1(@swc/core@1.3.92)(@types/node@20.8.4)(typescript@5.2.2))
+      '@jest/core': 29.7.0(ts-node@10.9.1(@swc/core@1.3.92(@swc/helpers@0.5.11))(@types/node@20.8.4)(typescript@5.2.2))
       '@jest/types': 29.6.3
       import-local: 3.1.0
-      jest-cli: 29.7.0(@types/node@20.12.11)(ts-node@10.9.1(@swc/core@1.3.92)(@types/node@20.8.4)(typescript@5.2.2))
+      jest-cli: 29.7.0(@types/node@20.12.11)(ts-node@10.9.1(@swc/core@1.3.92(@swc/helpers@0.5.11))(@types/node@20.8.4)(typescript@5.2.2))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
       - supports-color
       - ts-node
 
-  jest@29.7.0(@types/node@20.8.4)(ts-node@10.9.1(@swc/core@1.3.92)(@types/node@20.8.4)(typescript@5.2.2)):
+  jest@29.7.0(@types/node@20.8.4)(ts-node@10.9.1(@swc/core@1.3.92(@swc/helpers@0.5.11))(@types/node@20.8.4)(typescript@5.2.2)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.1(@swc/core@1.3.92)(@types/node@20.8.4)(typescript@5.2.2))
+      '@jest/core': 29.7.0(ts-node@10.9.1(@swc/core@1.3.92(@swc/helpers@0.5.11))(@types/node@20.8.4)(typescript@5.2.2))
       '@jest/types': 29.6.3
       import-local: 3.1.0
-      jest-cli: 29.7.0(@types/node@20.8.4)(ts-node@10.9.1(@swc/core@1.3.92)(@types/node@20.8.4)(typescript@5.2.2))
+      jest-cli: 29.7.0(@types/node@20.8.4)(ts-node@10.9.1(@swc/core@1.3.92(@swc/helpers@0.5.11))(@types/node@20.8.4)(typescript@5.2.2))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -30353,11 +30353,11 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  next-images@1.8.5(webpack@5.91.0(@swc/core@1.3.92)):
+  next-images@1.8.5(webpack@5.91.0(@swc/core@1.3.92(@swc/helpers@0.5.11))):
     dependencies:
-      file-loader: 6.2.0(webpack@5.91.0(@swc/core@1.3.92))
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.91.0(@swc/core@1.3.92)))(webpack@5.91.0(@swc/core@1.3.92))
-      webpack: 5.91.0(@swc/core@1.3.92)
+      file-loader: 6.2.0(webpack@5.91.0(@swc/core@1.3.92(@swc/helpers@0.5.11)))
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.91.0(@swc/core@1.3.92(@swc/helpers@0.5.11))))(webpack@5.91.0(@swc/core@1.3.92(@swc/helpers@0.5.11)))
+      webpack: 5.91.0(@swc/core@1.3.92(@swc/helpers@0.5.11))
 
   next-mdx-remote@4.4.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
@@ -30855,13 +30855,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  postcss-load-config@4.0.1(postcss@8.4.41)(ts-node@10.9.1(@swc/core@1.3.92)(@types/node@20.8.4)(typescript@5.2.2)):
+  postcss-load-config@4.0.1(postcss@8.4.41)(ts-node@10.9.1(@swc/core@1.3.92(@swc/helpers@0.5.11))(@types/node@20.12.11)(typescript@5.2.2)):
     dependencies:
       lilconfig: 2.1.0
       yaml: 2.3.1
     optionalDependencies:
       postcss: 8.4.41
-      ts-node: 10.9.1(@swc/core@1.3.92)(@types/node@20.8.4)(typescript@5.2.2)
+      ts-node: 10.9.1(@swc/core@1.3.92(@swc/helpers@0.5.11))(@types/node@20.12.11)(typescript@5.2.2)
 
   postcss-modules-extract-imports@3.0.0(postcss@8.4.38):
     dependencies:
@@ -31671,16 +31671,16 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  react-router-dom@6.16.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  react-router-dom@6.26.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      '@remix-run/router': 1.9.0
+      '@remix-run/router': 1.19.2
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      react-router: 6.16.0(react@18.3.1)
+      react-router: 6.26.2(react@18.3.1)
 
-  react-router@6.16.0(react@18.3.1):
+  react-router@6.26.2(react@18.3.1):
     dependencies:
-      '@remix-run/router': 1.9.0
+      '@remix-run/router': 1.19.2
       react: 18.3.1
 
   react-shallow-renderer@16.15.0(react@18.3.1):
@@ -32430,7 +32430,7 @@ snapshots:
 
   store2@2.14.2: {}
 
-  storybook-addon-react-router-v6@2.0.7(@storybook/blocks@7.4.6(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@storybook/channels@7.4.6)(@storybook/components@7.4.6(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@storybook/core-events@7.4.6)(@storybook/manager-api@7.4.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@storybook/preview-api@7.4.6)(@storybook/theming@7.4.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react-router-dom@6.16.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1):
+  storybook-addon-react-router-v6@2.0.7(@storybook/blocks@7.4.6(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@storybook/channels@7.4.6)(@storybook/components@7.4.6(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@storybook/core-events@7.4.6)(@storybook/manager-api@7.4.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@storybook/preview-api@7.4.6)(@storybook/theming@7.4.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react-router-dom@6.26.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1):
     dependencies:
       '@storybook/blocks': 7.4.6(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@storybook/channels': 7.4.6
@@ -32441,7 +32441,7 @@ snapshots:
       '@storybook/theming': 7.4.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       compare-versions: 6.1.0
       react-inspector: 6.0.2(react@18.3.1)
-      react-router-dom: 6.16.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-router-dom: 6.26.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     optionalDependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -32726,14 +32726,14 @@ snapshots:
 
   term-size@2.2.1: {}
 
-  terser-webpack-plugin@5.3.10(@swc/core@1.3.92)(webpack@5.91.0(@swc/core@1.3.92)):
+  terser-webpack-plugin@5.3.10(@swc/core@1.3.92(@swc/helpers@0.5.11))(webpack@5.91.0(@swc/core@1.3.92(@swc/helpers@0.5.11))):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       jest-worker: 27.5.1
       schema-utils: 3.3.0
       serialize-javascript: 6.0.2
       terser: 5.31.0
-      webpack: 5.91.0(@swc/core@1.3.92)
+      webpack: 5.91.0(@swc/core@1.3.92(@swc/helpers@0.5.11))
     optionalDependencies:
       '@swc/core': 1.3.92(@swc/helpers@0.5.11)
 
@@ -32857,15 +32857,15 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-jest-mock-import-meta@1.1.0(ts-jest@29.1.2(@babel/core@7.24.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.0))(esbuild@0.18.20)(jest@29.7.0(@types/node@20.12.11)(ts-node@10.9.1(@swc/core@1.3.92)(@types/node@20.8.4)(typescript@5.2.2)))(typescript@5.2.2)):
+  ts-jest-mock-import-meta@1.1.0(ts-jest@29.1.2(@babel/core@7.24.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.0))(esbuild@0.18.20)(jest@29.7.0(@types/node@20.12.11)(ts-node@10.9.1(@swc/core@1.3.92(@swc/helpers@0.5.11))(@types/node@20.8.4)(typescript@5.2.2)))(typescript@5.2.2)):
     dependencies:
-      ts-jest: 29.1.2(@babel/core@7.24.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.0))(esbuild@0.18.20)(jest@29.7.0(@types/node@20.12.11)(ts-node@10.9.1(@swc/core@1.3.92)(@types/node@20.8.4)(typescript@5.2.2)))(typescript@5.2.2)
+      ts-jest: 29.1.2(@babel/core@7.24.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.0))(esbuild@0.18.20)(jest@29.7.0(@types/node@20.12.11)(ts-node@10.9.1(@swc/core@1.3.92(@swc/helpers@0.5.11))(@types/node@20.8.4)(typescript@5.2.2)))(typescript@5.2.2)
 
-  ts-jest@29.1.1(@babel/core@7.23.2)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.23.2))(jest@29.7.0(@types/node@20.8.4)(ts-node@10.9.1(@swc/core@1.3.92)(@types/node@20.8.4)(typescript@5.2.2)))(typescript@5.2.2):
+  ts-jest@29.1.1(@babel/core@7.23.2)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.23.2))(jest@29.7.0(@types/node@20.8.4)(ts-node@10.9.1(@swc/core@1.3.92(@swc/helpers@0.5.11))(@types/node@20.8.4)(typescript@5.2.2)))(typescript@5.2.2):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0(@types/node@20.8.4)(ts-node@10.9.1(@swc/core@1.3.92)(@types/node@20.8.4)(typescript@5.2.2))
+      jest: 29.7.0(@types/node@20.8.4)(ts-node@10.9.1(@swc/core@1.3.92(@swc/helpers@0.5.11))(@types/node@20.8.4)(typescript@5.2.2))
       jest-util: 29.6.2
       json5: 2.2.3
       lodash.memoize: 4.1.2
@@ -32878,11 +32878,11 @@ snapshots:
       '@jest/types': 29.6.3
       babel-jest: 29.7.0(@babel/core@7.23.2)
 
-  ts-jest@29.1.1(@babel/core@7.24.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.0))(esbuild@0.18.20)(jest@29.7.0(@types/node@20.12.11)(ts-node@10.9.1(@swc/core@1.3.92)(@types/node@20.8.4)(typescript@5.2.2)))(typescript@5.2.2):
+  ts-jest@29.1.1(@babel/core@7.24.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.0))(esbuild@0.18.20)(jest@29.7.0(@types/node@20.12.11)(ts-node@10.9.1(@swc/core@1.3.92(@swc/helpers@0.5.11))(@types/node@20.8.4)(typescript@5.2.2)))(typescript@5.2.2):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0(@types/node@20.12.11)(ts-node@10.9.1(@swc/core@1.3.92)(@types/node@20.8.4)(typescript@5.2.2))
+      jest: 29.7.0(@types/node@20.12.11)(ts-node@10.9.1(@swc/core@1.3.92(@swc/helpers@0.5.11))(@types/node@20.8.4)(typescript@5.2.2))
       jest-util: 29.6.2
       json5: 2.2.3
       lodash.memoize: 4.1.2
@@ -32896,11 +32896,11 @@ snapshots:
       babel-jest: 29.7.0(@babel/core@7.24.0)
       esbuild: 0.18.20
 
-  ts-jest@29.1.2(@babel/core@7.24.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.0))(esbuild@0.18.20)(jest@29.7.0(@types/node@20.12.11)(ts-node@10.9.1(@swc/core@1.3.92)(@types/node@20.8.4)(typescript@5.2.2)))(typescript@5.2.2):
+  ts-jest@29.1.2(@babel/core@7.24.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.0))(esbuild@0.18.20)(jest@29.7.0(@types/node@20.12.11)(ts-node@10.9.1(@swc/core@1.3.92(@swc/helpers@0.5.11))(@types/node@20.8.4)(typescript@5.2.2)))(typescript@5.2.2):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0(@types/node@20.12.11)(ts-node@10.9.1(@swc/core@1.3.92)(@types/node@20.8.4)(typescript@5.2.2))
+      jest: 29.7.0(@types/node@20.12.11)(ts-node@10.9.1(@swc/core@1.3.92(@swc/helpers@0.5.11))(@types/node@20.8.4)(typescript@5.2.2))
       jest-util: 29.7.0
       json5: 2.2.3
       lodash.memoize: 4.1.2
@@ -32914,7 +32914,28 @@ snapshots:
       babel-jest: 29.7.0(@babel/core@7.24.0)
       esbuild: 0.18.20
 
-  ts-node@10.9.1(@swc/core@1.3.92)(@types/node@20.8.4)(typescript@5.2.2):
+  ts-node@10.9.1(@swc/core@1.3.92(@swc/helpers@0.5.11))(@types/node@20.12.11)(typescript@5.2.2):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.9
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 20.12.11
+      acorn: 8.10.0
+      acorn-walk: 8.2.0
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.2.2
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optionalDependencies:
+      '@swc/core': 1.3.92(@swc/helpers@0.5.11)
+    optional: true
+
+  ts-node@10.9.1(@swc/core@1.3.92(@swc/helpers@0.5.11))(@types/node@20.8.4)(typescript@5.2.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.9
@@ -32956,7 +32977,7 @@ snapshots:
 
   tslib@2.6.2: {}
 
-  tsup@7.2.0(@swc/core@1.3.92)(postcss@8.4.41)(ts-node@10.9.1(@swc/core@1.3.92)(@types/node@20.8.4)(typescript@5.2.2))(typescript@5.2.2):
+  tsup@7.2.0(@swc/core@1.3.92(@swc/helpers@0.5.11))(postcss@8.4.41)(ts-node@10.9.1(@swc/core@1.3.92(@swc/helpers@0.5.11))(@types/node@20.12.11)(typescript@5.2.2))(typescript@5.2.2):
     dependencies:
       bundle-require: 4.0.1(esbuild@0.18.20)
       cac: 6.7.14
@@ -32966,7 +32987,7 @@ snapshots:
       execa: 5.1.1
       globby: 11.1.0
       joycon: 3.1.1
-      postcss-load-config: 4.0.1(postcss@8.4.41)(ts-node@10.9.1(@swc/core@1.3.92)(@types/node@20.8.4)(typescript@5.2.2))
+      postcss-load-config: 4.0.1(postcss@8.4.41)(ts-node@10.9.1(@swc/core@1.3.92(@swc/helpers@0.5.11))(@types/node@20.12.11)(typescript@5.2.2))
       resolve-from: 5.0.0
       rollup: 3.29.5
       source-map: 0.8.0-beta.0
@@ -33295,14 +33316,14 @@ snapshots:
 
   url-join@4.0.1: {}
 
-  url-loader@4.1.1(file-loader@6.2.0(webpack@5.91.0(@swc/core@1.3.92)))(webpack@5.91.0(@swc/core@1.3.92)):
+  url-loader@4.1.1(file-loader@6.2.0(webpack@5.91.0(@swc/core@1.3.92(@swc/helpers@0.5.11))))(webpack@5.91.0(@swc/core@1.3.92(@swc/helpers@0.5.11))):
     dependencies:
       loader-utils: 2.0.4
       mime-types: 2.1.35
       schema-utils: 3.3.0
-      webpack: 5.91.0(@swc/core@1.3.92)
+      webpack: 5.91.0(@swc/core@1.3.92(@swc/helpers@0.5.11))
     optionalDependencies:
-      file-loader: 6.2.0(webpack@5.91.0(@swc/core@1.3.92))
+      file-loader: 6.2.0(webpack@5.91.0(@swc/core@1.3.92(@swc/helpers@0.5.11)))
 
   url-parse@1.5.10:
     dependencies:
@@ -33681,7 +33702,7 @@ snapshots:
       - esbuild
       - uglify-js
 
-  webpack@5.91.0(@swc/core@1.3.92):
+  webpack@5.91.0(@swc/core@1.3.92(@swc/helpers@0.5.11)):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.5
@@ -33704,7 +33725,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.10(@swc/core@1.3.92)(webpack@5.91.0(@swc/core@1.3.92))
+      terser-webpack-plugin: 5.3.10(@swc/core@1.3.92(@swc/helpers@0.5.11))(webpack@5.91.0(@swc/core@1.3.92(@swc/helpers@0.5.11)))
       watchpack: 2.4.1
       webpack-sources: 3.2.3
     transitivePeerDependencies:


### PR DESCRIPTION
# Changes

## Fuel Wallet
- Fixed not being able to add a known token on a different network. Closes #1499 
- Fixed being able to manually create custom assets with duplicate asset ids. Closes #1503 
- Fixed routes not supporting optional parameters and not processing parameter values correctly in some instances. Closes #1511 

# Evidence


https://github.com/user-attachments/assets/77b3f24a-b7c4-42dc-ae6a-6f9916ca85b9



https://github.com/user-attachments/assets/8db99142-41a7-48df-a0bd-9f5f127dce84


