### PR TITLE
fix: wallet not communicating with vault during setup

### DIFF
--- a/.changeset/swift-goats-cheat.md
+++ b/.changeset/swift-goats-cheat.md
@@ -1,0 +1,5 @@
+---
+"fuels-wallet": patch
+---
+
+Added missing parameter to destroy window listener on ContentScript when the page/tab is closed

--- a/.changeset/tricky-roses-end.md
+++ b/.changeset/tricky-roses-end.md
@@ -1,0 +1,5 @@
+---
+"fuels-wallet": patch
+---
+
+Added port disconnection detection and restart to `VaultCRXConnector`. Fixes wallet setup not finalizing

--- a/packages/app/src/systems/CRX/scripts/contentScript.ts
+++ b/packages/app/src/systems/CRX/scripts/contentScript.ts
@@ -5,5 +5,5 @@ const connection = ContentProxyConnection.start(WALLET_NAME);
 
 // Ensure cleanup when the content script is unloaded
 window.addEventListener('beforeunload', () => {
-  connection.destroy();
+  connection.destroy(false);
 });

--- a/packages/app/src/systems/Vault/connectors/VaultCRXConnector.ts
+++ b/packages/app/src/systems/Vault/connectors/VaultCRXConnector.ts
@@ -28,6 +28,7 @@ export class VaultCRXConnector {
     this.clientVault.connection = chrome.runtime.connect(chrome.runtime.id, {
       name: VAULT_SCRIPT_NAME,
     });
+    this.clientVault.connection.onDisconnect.addListener(this.destroy);
     this.clientVault.connection.onMessage.addListener(
       this.onCommunicationMessage
     );
@@ -74,5 +75,7 @@ export class VaultCRXConnector {
     this.clientVault.connection?.onMessage.removeListener(
       this.onCommunicationMessage
     );
+    this.clientVault.connection?.onDisconnect.removeListener(this.destroy);
+    this.clientVault.connection = undefined;
   }
 }

--- a/packages/app/src/systems/Vault/connectors/VaultCRXConnector.ts
+++ b/packages/app/src/systems/Vault/connectors/VaultCRXConnector.ts
@@ -11,21 +11,26 @@ import type { JSONRPCRequest } from 'json-rpc-2.0';
 import type { VaultClient } from '../services/VaultClient';
 
 export class VaultCRXConnector {
-  connection: chrome.runtime.Port | undefined;
   readonly clientVault: VaultClient;
 
   constructor(clientVault: VaultClient) {
     this.clientVault = clientVault;
-    this.clientVault.onRequest = this.onRequest.bind(this);
+    this.onRequest = this.onRequest.bind(this);
+    this.clientVault.onRequest = this.onRequest;
+    this.onResponse = this.onResponse.bind(this);
+    this.onEvent = this.onEvent.bind(this);
+    this.destroy = this.destroy.bind(this);
     this.onCommunicationMessage = this.onCommunicationMessage.bind(this);
     this.connectAndAttachListeners();
   }
 
   connectAndAttachListeners() {
-    this.connection = chrome.runtime.connect(chrome.runtime.id, {
+    this.clientVault.connection = chrome.runtime.connect(chrome.runtime.id, {
       name: VAULT_SCRIPT_NAME,
     });
-    this.connection.onMessage.addListener(this.onCommunicationMessage);
+    this.clientVault.connection.onMessage.addListener(
+      this.onCommunicationMessage
+    );
   }
 
   onCommunicationMessage = (message: CommunicationMessage) => {
@@ -41,31 +46,33 @@ export class VaultCRXConnector {
     }
   };
 
-  async onEvent(message: EventMessage) {
+  onEvent(message: EventMessage) {
     // biome-ignore lint/complexity/noForEach: <explanation>
     message.events.forEach((event) => {
       this.clientVault.emit(event.event, ...event.params);
     });
   }
 
-  async onResponse(message: ResponseMessage) {
+  onResponse(message: ResponseMessage) {
     this.clientVault.client.receive(message.response);
   }
 
-  async onRequest(request: JSONRPCRequest): Promise<void> {
+  async onRequest(request: JSONRPCRequest) {
     if (!request) return;
-    if (!this.connection) this.connectAndAttachListeners();
-    if (this.connection) {
+    if (!this.clientVault.connection) this.connectAndAttachListeners();
+    if (this.clientVault.connection) {
       const responseMessage: RequestMessage = {
         target: VAULT_SCRIPT_NAME,
         type: MessageTypes.request,
         request,
       };
-      this.connection.postMessage(responseMessage);
+      this.clientVault.connection.postMessage(responseMessage);
     }
   }
 
   destroy() {
-    this.connection?.onMessage.removeListener(this.onCommunicationMessage);
+    this.clientVault.connection?.onMessage.removeListener(
+      this.onCommunicationMessage
+    );
   }
 }

--- a/packages/app/src/systems/Vault/services/VaultClient.ts
+++ b/packages/app/src/systems/Vault/services/VaultClient.ts
@@ -10,7 +10,7 @@ import { VaultServer } from './VaultServer';
 
 export class VaultClient extends EventEmitter {
   readonly client: JSONRPCClient;
-
+  connection: chrome.runtime.Port | undefined;
   constructor() {
     super();
     // Setup client JSONRPC


### PR DESCRIPTION
Closes #1517 

- Moved `connection` prop from `VaultCRXConnector` to `Vault` client, as `VaultCRXConnector`'s `onRequest` method executes on `Vault`'s instance it'd fail to fetch the current `connected` data. 
- Added port disconnection detection and restart to `VaultCRXConnector`. Fixes wallet setup not finalizing
- Added missing parameter to destroy window listener on ContentScript when the page/tab is closed