### PR TITLE
fix: broken release rc action

### DIFF
--- a/.github/workflows/release-npm-changeset.yaml
+++ b/.github/workflows/release-npm-changeset.yaml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Create Release Pull Request or Publish to NPM
         id: changesets
-        uses: FuelLabs/changesets-action@main
+        uses: FuelLabs/changesets-action@v2.0.0
         with:
           publish: pnpm changeset publish --tag next
           commit: "ci(changesets): versioning packages"


### PR DESCRIPTION

- Fixes using version of `Fuellabs/changesets` incompatible with our `@changeset/cli`


Evidence: https://github.com/FuelLabs/fuels-wallet/actions/runs/11151940944/job/30996473996