### PR TITLE
refactor: transaction estimation flow

### DIFF
--- a/.changeset/gentle-insects-drum.md
+++ b/.changeset/gentle-insects-drum.md
@@ -1,0 +1,5 @@
+---
+"fuels-wallet": minor
+---
+
+Increase gasLimit by 20% to avoid OutOfGas error

--- a/.changeset/tasty-deers-remain.md
+++ b/.changeset/tasty-deers-remain.md
@@ -1,0 +1,5 @@
+---
+"fuels-wallet": minor
+---
+
+Refactor transaction estimation / customization of fees flow

--- a/packages/app/src/systems/Core/utils/wallet.ts
+++ b/packages/app/src/systems/Core/utils/wallet.ts
@@ -42,9 +42,14 @@ export class WalletLockedCustom extends WalletLocked {
     transactionRequestLike: TransactionRequestLike
   ): Promise<TransactionResponse> {
     const transactionRequest = transactionRequestify(transactionRequestLike);
-    await this.provider.estimateTxDependencies(transactionRequest);
     const txRequestToSend =
       await this.populateTransactionWitnessesSignature(transactionRequest);
-    return this.provider.sendTransaction(txRequestToSend);
+
+    await this.simulateTransaction(txRequestToSend, {
+      estimateTxDependencies: false,
+    });
+    return this.provider.sendTransaction(txRequestToSend, {
+      estimateTxDependencies: false,
+    });
   }
 }

--- a/packages/app/src/systems/DApp/hooks/useTransactionRequest.tsx
+++ b/packages/app/src/systems/DApp/hooks/useTransactionRequest.tsx
@@ -23,6 +23,9 @@ const selectors = {
   txSummaryExecuted(state: TransactionRequestState) {
     return state.context.response?.txSummaryExecuted;
   },
+  proposedTxRequest(state: TransactionRequestState) {
+    return state.context.response?.proposedTxRequest;
+  },
   isLoadingAccounts(state: TransactionRequestState) {
     return state.matches('fetchingAccount');
   },
@@ -102,6 +105,7 @@ export function useTransactionRequest(opts: UseTransactionRequestOpts = {}) {
   const title = useSelector(service, selectors.title);
   const txSummarySimulated = useSelector(service, selectors.txSummarySimulated);
   const txSummaryExecuted = useSelector(service, selectors.txSummaryExecuted);
+  const proposedTxRequest = useSelector(service, selectors.proposedTxRequest);
   const origin = useSelector(service, selectors.origin);
   const originTitle = useSelector(service, selectors.originTitle);
   const favIconUrl = useSelector(service, selectors.favIconUrl);
@@ -174,6 +178,7 @@ export function useTransactionRequest(opts: UseTransactionRequestOpts = {}) {
     shouldDisableApproveBtn,
     shouldShowTxSimulated,
     shouldShowTxExecuted,
+    proposedTxRequest,
     handlers: {
       request,
       reset,

--- a/packages/app/src/systems/DApp/pages/TransactionRequest/TransactionRequest.FormProvider.tsx
+++ b/packages/app/src/systems/DApp/pages/TransactionRequest/TransactionRequest.FormProvider.tsx
@@ -20,7 +20,6 @@ export type TransactionRequestFormData = {
 
 type SchemaOptions = {
   baseFee: BN | undefined;
-  minGasLimit: BN | undefined;
   maxGasLimit: BN | undefined;
 };
 
@@ -48,23 +47,6 @@ const schema = yup
         gasLimit: yup.object({
           amount: yup
             .mixed<BN>()
-            .test({
-              name: 'min',
-              test: (value, ctx) => {
-                const { minGasLimit } = ctx.options.context as SchemaOptions;
-
-                if (!minGasLimit || value?.gte(minGasLimit)) {
-                  return true;
-                }
-
-                return ctx.createError({
-                  path: 'fees.gasLimit',
-                  message: `Gas limit must be greater than or equal to ${formatGasLimit(
-                    minGasLimit
-                  )}.`,
-                });
-              },
-            })
             .test({
               name: 'max',
               test: (value, ctx) => {

--- a/packages/app/src/systems/DApp/pages/TransactionRequest/TransactionRequest.tsx
+++ b/packages/app/src/systems/DApp/pages/TransactionRequest/TransactionRequest.tsx
@@ -5,7 +5,7 @@ import { useMemo } from 'react';
 import { useAssets } from '~/systems/Asset';
 import { Layout } from '~/systems/Core';
 import { TopBarType } from '~/systems/Core/components/Layout/TopBar';
-import { TxContent } from '~/systems/Transaction';
+import { TxContent, getGasLimitFromTxRequest } from '~/systems/Transaction';
 import { formatTip } from '~/systems/Transaction/components/TxFeeOptions/TxFeeOptions.utils';
 import { useTransactionRequest } from '../../hooks/useTransactionRequest';
 import { AutoSubmit } from './TransactionRequest.AutoSubmit';
@@ -38,8 +38,7 @@ export function TransactionRequest() {
     if (!txSummarySimulated || !proposedTxRequest) return undefined;
 
     const tip = bn(proposedTxRequest.tip);
-    // biome-ignore lint/suspicious/noExplicitAny: <explanation>
-    const gasLimit = (proposedTxRequest as any)?.gasLimit;
+    const gasLimit = getGasLimitFromTxRequest(proposedTxRequest);
 
     return {
       fees: {

--- a/packages/app/src/systems/DApp/pages/TransactionRequest/TransactionRequest.tsx
+++ b/packages/app/src/systems/DApp/pages/TransactionRequest/TransactionRequest.tsx
@@ -1,5 +1,6 @@
 import { cssObj } from '@fuel-ui/css';
 import { Button } from '@fuel-ui/react';
+import { bn } from 'fuels';
 import { useMemo } from 'react';
 import { useAssets } from '~/systems/Asset';
 import { Layout } from '~/systems/Core';
@@ -29,14 +30,16 @@ export function TransactionRequest() {
     shouldDisableApproveBtn,
     errors,
     executedStatus,
+    proposedTxRequest,
   } = txRequest;
   const { isLoading: isLoadingAssets } = useAssets();
 
   const defaultValues = useMemo<TransactionRequestFormData | undefined>(() => {
-    if (!txSummarySimulated) return undefined;
+    if (!txSummarySimulated || !proposedTxRequest) return undefined;
 
-    const tip = txSummarySimulated.tip;
-    const gasLimit = txSummarySimulated.gasUsed;
+    const tip = bn(proposedTxRequest.tip);
+    // biome-ignore lint/suspicious/noExplicitAny: <explanation>
+    const gasLimit = (proposedTxRequest as any)?.gasLimit;
 
     return {
       fees: {
@@ -50,7 +53,7 @@ export function TransactionRequest() {
         },
       },
     };
-  }, [txSummarySimulated]);
+  }, [txSummarySimulated, proposedTxRequest]);
 
   const isLoadingInfo = useMemo<boolean>(() => {
     return status('loading') || status('sending') || isLoadingAssets;
@@ -74,7 +77,6 @@ export function TransactionRequest() {
       testId={txRequest.txStatus}
       context={{
         baseFee: fees.baseFee,
-        minGasLimit: fees.minGasLimit,
         maxGasLimit: fees.maxGasLimit,
       }}
     >
@@ -87,6 +89,7 @@ export function TransactionRequest() {
             <TxContent.Info
               showDetails
               tx={txSummarySimulated}
+              txRequest={proposedTxRequest}
               isLoading={isLoadingInfo}
               errors={errors.simulateTxErrors}
               isConfirm

--- a/packages/app/src/systems/Send/components/SendSelect/SendSelect.tsx
+++ b/packages/app/src/systems/Send/components/SendSelect/SendSelect.tsx
@@ -171,7 +171,7 @@ export function SendSelect({
               <TxFeeOptions
                 initialAdvanced={false}
                 baseFee={baseFee}
-                minGasLimit={minGasLimit}
+                gasLimit={minGasLimit}
                 regularTip={regularTip}
                 fastTip={fastTip}
               />

--- a/packages/app/src/systems/Send/components/SendSelect/SendSelect.tsx
+++ b/packages/app/src/systems/Send/components/SendSelect/SendSelect.tsx
@@ -26,7 +26,7 @@ export function SendSelect({
   balances,
   balanceAssetSelected,
   baseFee = bn(0),
-  minGasLimit = bn(0),
+  gasLimit = bn(0),
   tip,
   regularTip,
   fastTip,
@@ -171,7 +171,7 @@ export function SendSelect({
               <TxFeeOptions
                 initialAdvanced={false}
                 baseFee={baseFee}
-                gasLimit={minGasLimit}
+                gasLimit={gasLimit}
                 regularTip={regularTip}
                 fastTip={fastTip}
               />

--- a/packages/app/src/systems/Send/hooks/useSend.tsx
+++ b/packages/app/src/systems/Send/hooks/useSend.tsx
@@ -24,8 +24,8 @@ export enum SendStatus {
 }
 
 const selectors = {
-  minGasLimit(state: SendMachineState) {
-    return state.context.minGasLimit;
+  gasLimit(state: SendMachineState) {
+    return state.context.gasLimit;
   },
   maxGasLimit(state: SendMachineState) {
     return state.context.maxGasLimit;
@@ -73,7 +73,7 @@ type BalanceAsset = {
 type SchemaOptions = {
   balances: BalanceAsset[];
   baseFee: BN | undefined;
-  minGasLimit: BN | undefined;
+  gasLimit: BN | undefined;
   maxGasLimit: BN | undefined;
 };
 
@@ -161,23 +161,6 @@ const schema = yup
           amount: yup
             .mixed<BN>()
             .test({
-              name: 'min',
-              test: (value, ctx) => {
-                const { minGasLimit } = ctx.options.context as SchemaOptions;
-
-                if (!minGasLimit || value?.gte(minGasLimit)) {
-                  return true;
-                }
-
-                return ctx.createError({
-                  path: 'fees.gasLimit',
-                  message: `Gas limit must be greater than or equal to ${formatGasLimit(
-                    minGasLimit
-                  )}.`,
-                });
-              },
-            })
-            .test({
               name: 'max',
               test: (value, ctx) => {
                 const { maxGasLimit } = ctx.options.context as SchemaOptions;
@@ -254,7 +237,6 @@ export function useSend() {
             baseFee,
             regularTip,
             fastTip,
-            minGasLimit,
             maxGasLimit,
           } = ctx;
           if (!providerUrl || !transactionRequest || !address) {
@@ -269,7 +251,6 @@ export function useSend() {
               baseFee,
               regularTip,
               fastTip,
-              minGasLimit,
               maxGasLimit,
             },
             skipCustomFee: true,
@@ -280,7 +261,7 @@ export function useSend() {
   );
 
   const baseFee = useSelector(service, selectors.baseFee);
-  const minGasLimit = useSelector(service, selectors.minGasLimit);
+  const gasLimit = useSelector(service, selectors.gasLimit);
   const maxGasLimit = useSelector(service, selectors.maxGasLimit);
   const errorMessage = useSelector(service, selectors.error);
 
@@ -291,7 +272,7 @@ export function useSend() {
     context: {
       balances: account?.balances,
       baseFee,
-      minGasLimit,
+      gasLimit,
       maxGasLimit,
     },
   });
@@ -376,7 +357,7 @@ export function useSend() {
   return {
     form,
     baseFee,
-    minGasLimit,
+    gasLimit,
     tip,
     regularTip,
     fastTip,

--- a/packages/app/src/systems/Send/machines/sendMachine.ts
+++ b/packages/app/src/systems/Send/machines/sendMachine.ts
@@ -22,7 +22,7 @@ export type MachineContext = {
   baseFee?: BN;
   regularTip?: BN;
   fastTip?: BN;
-  minGasLimit?: BN;
+  gasLimit?: BN;
   maxGasLimit?: BN;
   input?: TxInputs['createTransfer'];
   error?: string;
@@ -39,7 +39,7 @@ type EstimateGasLimitReturn = {
 
 type CreateTransactionReturn = {
   baseFee?: BN;
-  minGasLimit?: BN;
+  gasLimit?: BN;
   transactionRequest?: TransactionRequest;
   providerUrl: string;
   address: string;
@@ -182,7 +182,7 @@ export const sendMachine = createMachine(
         providerUrl: ev.data.providerUrl,
         address: ev.data.address,
         baseFee: ev.data.baseFee ?? ctx.baseFee,
-        minGasLimit: ev.data.minGasLimit ?? ctx.minGasLimit,
+        gasLimit: ev.data.gasLimit ?? ctx.gasLimit,
         error: undefined,
       })),
     },

--- a/packages/app/src/systems/Transaction/components/TxContent/TxContent.stories.tsx
+++ b/packages/app/src/systems/Transaction/components/TxContent/TxContent.stories.tsx
@@ -26,7 +26,6 @@ const defaultArgs = {
   txStatus: TransactionStatus.success,
   fees: {
     baseFee: bn(0.01),
-    minGasLimit: bn(0.01),
     regularTip: bn(0.01),
     fastTip: bn(0.01),
   },

--- a/packages/app/src/systems/Transaction/components/TxContent/TxContent.tsx
+++ b/packages/app/src/systems/Transaction/components/TxContent/TxContent.tsx
@@ -92,7 +92,6 @@ export type TxContentInfoProps = {
   errors?: GroupedErrors;
   fees?: {
     baseFee?: BN;
-    minGasLimit?: BN;
     regularTip?: BN;
     fastTip?: BN;
   };

--- a/packages/app/src/systems/Transaction/components/TxContent/TxContent.tsx
+++ b/packages/app/src/systems/Transaction/components/TxContent/TxContent.tsx
@@ -25,6 +25,7 @@ import {
   TxFee,
   TxHeader,
   TxOperations,
+  getGasLimitFromTxRequest,
 } from '~/systems/Transaction';
 import { TxFeeOptions } from '../TxFeeOptions/TxFeeOptions';
 
@@ -114,8 +115,7 @@ function TxContentInfo({
   const status = txStatus || tx?.status || txStatus;
   const hasErrors = Boolean(Object.keys(errors || {}).length);
   const isExecuted = !!tx?.id;
-  // biome-ignore lint/suspicious/noExplicitAny: <explanation>
-  const txRequestGasLimit = (txRequest as any)?.gasLimit;
+  const txRequestGasLimit = getGasLimitFromTxRequest(txRequest);
 
   const initialAdvanced = useMemo(() => {
     if (!fees?.regularTip || !fees?.fastTip) return false;

--- a/packages/app/src/systems/Transaction/components/TxFeeOptions/TxFeeOptions.tsx
+++ b/packages/app/src/systems/Transaction/components/TxFeeOptions/TxFeeOptions.tsx
@@ -17,7 +17,7 @@ import {
 type TxFeeOptionsProps = {
   initialAdvanced: boolean;
   baseFee: BN;
-  minGasLimit: BN;
+  gasLimit: BN;
   regularTip: BN;
   fastTip: BN;
 };
@@ -25,13 +25,13 @@ type TxFeeOptionsProps = {
 export const TxFeeOptions = ({
   initialAdvanced,
   baseFee,
-  minGasLimit,
+  gasLimit: gasLimitInput,
   regularTip,
   fastTip,
 }: TxFeeOptionsProps) => {
   const { control, setValue, getValues } = useFormContext<SendFormValues>();
   const [isAdvanced, setIsAdvanced] = useState(initialAdvanced);
-  const previousMinGasLimit = useRef<BN>(minGasLimit);
+  const previousGasLimit = useRef<BN>(gasLimitInput);
   const previousDefaultTip = useRef<BN>(regularTip);
 
   const { field: tip, fieldState: tipState } = useController({
@@ -65,10 +65,10 @@ export const TxFeeOptions = ({
         'fees.gasLimit.amount',
       ]);
 
-      if (!currentGasLimit.eq(previousMinGasLimit.current)) {
+      if (!currentGasLimit.eq(previousGasLimit.current)) {
         setValue('fees.gasLimit', {
-          amount: previousMinGasLimit.current,
-          text: previousMinGasLimit.current.toString(),
+          amount: previousGasLimit.current,
+          text: previousGasLimit.current.toString(),
         });
       }
 

--- a/packages/app/src/systems/Transaction/services/transaction.tsx
+++ b/packages/app/src/systems/Transaction/services/transaction.tsx
@@ -249,9 +249,15 @@ export class TxService {
         proposedTxRequest.tip ?? bn(0)
       );
 
+      // Adding 1 magical unit to match the fake unit that is added on TS SDK (.add(1))
+      const feeAdaptedToSdkDiff = txSummary.fee.add(1);
+
       return {
         baseFee,
-        txSummary,
+        txSummary: {
+          ...txSummary,
+          fee: feeAdaptedToSdkDiff,
+        },
         proposedTxRequest,
       };
     } catch (e) {

--- a/packages/app/src/systems/Transaction/services/transaction.tsx
+++ b/packages/app/src/systems/Transaction/services/transaction.tsx
@@ -51,7 +51,6 @@ export type TxInputs = {
       baseFee?: BN;
       regularTip?: BN;
       fastTip?: BN;
-      minGasLimit?: BN;
       maxGasLimit?: BN;
     };
   };
@@ -388,16 +387,14 @@ export class TxService {
           }
         );
 
-        // Getting updated maxFee and costs
-        const txCost = await wallet.getTransactionCost(transactionRequest);
-
         const baseFee = transactionRequest.maxFee.sub(
           transactionRequest.tip ?? bn(0)
         );
 
         return {
           baseFee,
-          minGasLimit: txCost.gasUsed,
+          // biome-ignore lint/suspicious/noExplicitAny: <explanation>
+          gasLimit: (transactionRequest as any).gasLimit,
           transactionRequest,
           address: account.address,
           providerUrl: network.url,
@@ -417,7 +414,7 @@ export class TxService {
 
     return {
       baseFee: undefined,
-      minGasLimit: undefined,
+      gasLimit: undefined,
       transactionRequest: undefined,
       address: account.address,
       providerUrl: network.url,

--- a/packages/app/src/systems/Transaction/utils/gasLimit.ts
+++ b/packages/app/src/systems/Transaction/utils/gasLimit.ts
@@ -1,8 +1,22 @@
-import type { BN } from 'fuels';
+import { type BN, type TransactionRequest, bn } from 'fuels';
 
 export const formatGasLimit = (value: BN) => {
   const hex = value.toHex();
   const gasLimit = BigInt(hex);
 
   return gasLimit.toLocaleString('en-US');
+};
+
+export const getGasLimitFromTxRequest = (txRequest?: TransactionRequest) => {
+  if (!txRequest || !('gasLimit' in txRequest)) return bn(0);
+
+  return txRequest.gasLimit;
+};
+export const setGasLimitToTxRequest = (
+  txRequest?: TransactionRequest,
+  gasLimit?: BN
+) => {
+  if (!txRequest || !('gasLimit' in txRequest) || !gasLimit) return undefined;
+
+  txRequest.gasLimit = gasLimit;
 };


### PR DESCRIPTION
- Closes #1546 

- Simplified the estimation / approval part of the DAPP Approve Transaction screen
- Send transaction part
  - Simulate transaction before sending, avoiding the user to spend gas in case of fail
  - Skip estimating dependencies at this point, on this approval step we don’t wanna change the tx anymore
- Refact the transaction estimation part:
  - Save the `initialTxRequest` as the one the dev first informed. All further changes will be always done based on this first tx informed
  - Do the estimation, fee changes, funding if needed, and generate a `proposedTxRequest` which may have some changes
    - this `proposedTxRequest` is gonna be the one to go for approval
    - If the user choose to customize gas or tips, we apply again to the `initialTxRequest` and create a new `proposetTxRequest`, this way we don’t continuously manipulate a transactionRequest. Instead we always have a safe start point
- If the user didn't customize the `gasLimit` we automatically increase 20% on it, avoiding OutOfGas errors
- Remove all `minGasLimit`, letting the user just inform the gas he wants, if it’s too low the dryRun will fail
- For the approve screen to start in “Advanced Mode”
  - It will be needed that the tip informed in the tx is different then the regularTip and fastTIp we calculated
  - Also the gas can be different from the one calculated on proposedTxRequest, this will also make the Advanced Mode initiated
