### PR TITLE
fix: duplicate instance of ContentScript causing black screen

### DIFF
--- a/.changeset/breezy-glasses-double.md
+++ b/.changeset/breezy-glasses-double.md
@@ -4,4 +4,4 @@
 "fuels-wallet": patch
 ---
 
-Fixed duplicate instances of ContentScript after extension sleep/wakeup. Closes #326
+Fixed duplicate instances of ContentScript after extension sleep/wakeup. Closes [#326](https://github.com/FuelLabs/fuel-connectors/issues/326)

--- a/.changeset/breezy-glasses-double.md
+++ b/.changeset/breezy-glasses-double.md
@@ -1,0 +1,7 @@
+---
+"@fuel-wallet/connections": patch
+"@fuel-wallet/types": patch
+"fuels-wallet": patch
+---
+
+Fixed duplicate instances of ContentScript after extension sleep/wakeup. Closes #326

--- a/.changeset/fast-terms-glow.md
+++ b/.changeset/fast-terms-glow.md
@@ -1,0 +1,5 @@
+---
+"fuels-wallet": patch
+---
+
+Ensure popup is closed on resolve timeout

--- a/packages/app/src/systems/CRX/background/services/PopUpService.ts
+++ b/packages/app/src/systems/CRX/background/services/PopUpService.ts
@@ -234,6 +234,7 @@ export class PopUpService {
     this.removeUIListeners();
     this.client.rejectAllPendingRequests('Service is being cleaned up');
     popups.delete(this.origin);
+    closePopUp(this.tabId!);
   }
 
   static destroyAll() {

--- a/packages/types/src/contentScript.ts
+++ b/packages/types/src/contentScript.ts
@@ -1,0 +1,4 @@
+export enum ContentScriptMessageTypes {
+  PING = 'ping',
+  PONG = 'pong',
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -8,3 +8,4 @@ export * from './constants';
 export * from './abi';
 export * from './error';
 export * from './database';
+export * from './contentScript';


### PR DESCRIPTION

- Fixed duplicate instances of ContentScript after extension sleep/wakeup. Closes [#326](https://github.com/FuelLabs/fuel-connectors/issues/326)
- Ensure extension PopUp is closed on service resolve timeout/rejection.
- Ensure extension PopUp is closed on class destroy