### PR TITLE
fix: flaky e2e contract tests

### DIFF
--- a/packages/e2e-contract-tests/playwright/e2e/DepositHalfEth.test.ts
+++ b/packages/e2e-contract-tests/playwright/e2e/DepositHalfEth.test.ts
@@ -55,14 +55,9 @@ test.describe('Deposit Half ETH', () => {
     const depositHalfButton = getButtonByText(page, 'Deposit Half ETH', true);
 
     await expect
-      .poll(
-        () =>
-          depositHalfButton
-            .isEnabled()
-            .then(() => true)
-            .catch(() => false),
-        { timeout: 15000 }
-      )
+      .poll(() => depositHalfButton.isEnabled().catch(() => false), {
+        timeout: 15000,
+      })
       .toBeTruthy();
     await depositHalfButton.click();
 

--- a/packages/e2e-contract-tests/playwright/e2e/DepositHalfEth.test.ts
+++ b/packages/e2e-contract-tests/playwright/e2e/DepositHalfEth.test.ts
@@ -54,7 +54,16 @@ test.describe('Deposit Half ETH', () => {
 
     const depositHalfButton = getButtonByText(page, 'Deposit Half ETH', true);
 
-    await page.waitForTimeout(3000);
+    await expect
+      .poll(
+        () =>
+          depositHalfButton
+            .isEnabled()
+            .then(() => true)
+            .catch(() => false),
+        { timeout: 15000 }
+      )
+      .toBeTruthy();
     await depositHalfButton.click();
 
     const walletNotificationPage =

--- a/packages/e2e-contract-tests/playwright/e2e/ForwardAndMintMulticall.test.ts
+++ b/packages/e2e-contract-tests/playwright/e2e/ForwardAndMintMulticall.test.ts
@@ -62,7 +62,16 @@ test.describe('Forward and Mint Multicall', () => {
       page,
       'Deposit And Mint Multicall'
     );
-    await page.waitForTimeout(2500);
+    await expect
+      .poll(
+        () =>
+          forwardHalfAndMintButton
+            .isEnabled()
+            .then(() => true)
+            .catch(() => false),
+        { timeout: 15000 }
+      )
+      .toBeTruthy();
     await forwardHalfAndMintButton.click();
 
     const walletNotificationPage =

--- a/packages/e2e-contract-tests/playwright/e2e/ForwardAndMintMulticall.test.ts
+++ b/packages/e2e-contract-tests/playwright/e2e/ForwardAndMintMulticall.test.ts
@@ -63,14 +63,9 @@ test.describe('Forward and Mint Multicall', () => {
       'Deposit And Mint Multicall'
     );
     await expect
-      .poll(
-        () =>
-          forwardHalfAndMintButton
-            .isEnabled()
-            .then(() => true)
-            .catch(() => false),
-        { timeout: 15000 }
-      )
+      .poll(() => forwardHalfAndMintButton.isEnabled().catch(() => false), {
+        timeout: 15000,
+      })
       .toBeTruthy();
     await forwardHalfAndMintButton.click();
 

--- a/packages/e2e-contract-tests/playwright/e2e/ForwardEth.test.ts
+++ b/packages/e2e-contract-tests/playwright/e2e/ForwardEth.test.ts
@@ -52,7 +52,16 @@ test.describe('Forward Eth', () => {
     await forwardEthInput.fill(forwardEthAmount);
 
     const forwardEthButton = getButtonByText(page, 'Forward ETH');
-    await page.waitForTimeout(2500);
+    await expect
+      .poll(
+        () =>
+          forwardEthButton
+            .isEnabled()
+            .then(() => true)
+            .catch(() => false),
+        { timeout: 15000 }
+      )
+      .toBeTruthy();
     await forwardEthButton.click();
 
     const walletNotificationPage =

--- a/packages/e2e-contract-tests/playwright/e2e/ForwardEth.test.ts
+++ b/packages/e2e-contract-tests/playwright/e2e/ForwardEth.test.ts
@@ -53,14 +53,9 @@ test.describe('Forward Eth', () => {
 
     const forwardEthButton = getButtonByText(page, 'Forward ETH');
     await expect
-      .poll(
-        () =>
-          forwardEthButton
-            .isEnabled()
-            .then(() => true)
-            .catch(() => false),
-        { timeout: 15000 }
-      )
+      .poll(() => forwardEthButton.isEnabled().catch(() => false), {
+        timeout: 15000,
+      })
       .toBeTruthy();
     await forwardEthButton.click();
 

--- a/packages/e2e-contract-tests/playwright/e2e/ForwardHalfAndExternalMint.test.ts
+++ b/packages/e2e-contract-tests/playwright/e2e/ForwardHalfAndExternalMint.test.ts
@@ -66,14 +66,9 @@ test.describe('Forward Half ETH and Mint External Custom Asset', () => {
       'Forward Half And External Mint'
     );
     await expect
-      .poll(
-        () =>
-          forwardHalfAndMintButton
-            .isEnabled()
-            .then(() => true)
-            .catch(() => false),
-        { timeout: 15000 }
-      )
+      .poll(() => forwardHalfAndMintButton.isEnabled().catch(() => false), {
+        timeout: 15000,
+      })
       .toBeTruthy();
     await forwardHalfAndMintButton.click();
 

--- a/packages/e2e-contract-tests/playwright/e2e/ForwardHalfAndExternalMint.test.ts
+++ b/packages/e2e-contract-tests/playwright/e2e/ForwardHalfAndExternalMint.test.ts
@@ -65,7 +65,16 @@ test.describe('Forward Half ETH and Mint External Custom Asset', () => {
       page,
       'Forward Half And External Mint'
     );
-    await page.waitForTimeout(2500);
+    await expect
+      .poll(
+        () =>
+          forwardHalfAndMintButton
+            .isEnabled()
+            .then(() => true)
+            .catch(() => false),
+        { timeout: 15000 }
+      )
+      .toBeTruthy();
     await forwardHalfAndMintButton.click();
 
     const walletNotificationPage =

--- a/packages/e2e-contract-tests/playwright/e2e/ForwardHalfAndMint.test.ts
+++ b/packages/e2e-contract-tests/playwright/e2e/ForwardHalfAndMint.test.ts
@@ -64,14 +64,9 @@ test.describe('Forward Half ETH and Mint Custom Asset', () => {
       'Forward Half And Mint'
     );
     await expect
-      .poll(
-        () =>
-          forwardHalfAndMintButton
-            .isEnabled()
-            .then(() => true)
-            .catch(() => false),
-        { timeout: 15000 }
-      )
+      .poll(() => forwardHalfAndMintButton.isEnabled().catch(() => false), {
+        timeout: 15000,
+      })
       .toBeTruthy();
     await forwardHalfAndMintButton.click();
 

--- a/packages/e2e-contract-tests/playwright/e2e/ForwardHalfAndMint.test.ts
+++ b/packages/e2e-contract-tests/playwright/e2e/ForwardHalfAndMint.test.ts
@@ -63,7 +63,16 @@ test.describe('Forward Half ETH and Mint Custom Asset', () => {
       page,
       'Forward Half And Mint'
     );
-    await page.waitForTimeout(2500);
+    await expect
+      .poll(
+        () =>
+          forwardHalfAndMintButton
+            .isEnabled()
+            .then(() => true)
+            .catch(() => false),
+        { timeout: 15000 }
+      )
+      .toBeTruthy();
     await forwardHalfAndMintButton.click();
 
     const walletNotificationPage =

--- a/packages/e2e-contract-tests/playwright/e2e/ForwardHalfCustomAsset.test.ts
+++ b/packages/e2e-contract-tests/playwright/e2e/ForwardHalfCustomAsset.test.ts
@@ -77,14 +77,9 @@ test.describe('Forward Half Custom Asset', () => {
       'Forward Half Custom Asset'
     );
     await expect
-      .poll(
-        () =>
-          forwardHalfCustomAssetButton
-            .isEnabled()
-            .then(() => true)
-            .catch(() => false),
-        { timeout: 15000 }
-      )
+      .poll(() => forwardHalfCustomAssetButton.isEnabled().catch(() => false), {
+        timeout: 15000,
+      })
       .toBeTruthy();
     await forwardHalfCustomAssetButton.click();
 

--- a/packages/e2e-contract-tests/playwright/e2e/ForwardHalfCustomAsset.test.ts
+++ b/packages/e2e-contract-tests/playwright/e2e/ForwardHalfCustomAsset.test.ts
@@ -76,7 +76,16 @@ test.describe('Forward Half Custom Asset', () => {
       page,
       'Forward Half Custom Asset'
     );
-    await page.waitForTimeout(2500);
+    await expect
+      .poll(
+        () =>
+          forwardHalfCustomAssetButton
+            .isEnabled()
+            .then(() => true)
+            .catch(() => false),
+        { timeout: 15000 }
+      )
+      .toBeTruthy();
     await forwardHalfCustomAssetButton.click();
 
     const walletNotificationPage =

--- a/packages/e2e-contract-tests/playwright/e2e/MintAsset.test.ts
+++ b/packages/e2e-contract-tests/playwright/e2e/MintAsset.test.ts
@@ -54,7 +54,16 @@ test.describe('Mint Assets', () => {
     await mintInput.fill(mintAmount);
 
     const mintButton = getButtonByText(page, 'Mint', true);
-    await page.waitForTimeout(3000);
+    await expect
+      .poll(
+        () =>
+          mintButton
+            .isEnabled()
+            .then(() => true)
+            .catch(() => false),
+        { timeout: 15000 }
+      )
+      .toBeTruthy();
     await mintButton.click();
 
     // test asset is correct
@@ -126,7 +135,16 @@ test.describe('Mint Assets', () => {
     await decimalsInput.fill(decimals);
 
     const mintButton = getButtonByText(page, 'Mint Asset configuration');
-    await page.waitForTimeout(3000);
+    await expect
+      .poll(
+        () =>
+          mintButton
+            .isEnabled()
+            .then(() => true)
+            .catch(() => false),
+        { timeout: 15000 }
+      )
+      .toBeTruthy();
     await mintButton.click();
 
     // test asset is correct

--- a/packages/e2e-contract-tests/playwright/e2e/MintAsset.test.ts
+++ b/packages/e2e-contract-tests/playwright/e2e/MintAsset.test.ts
@@ -55,14 +55,7 @@ test.describe('Mint Assets', () => {
 
     const mintButton = getButtonByText(page, 'Mint', true);
     await expect
-      .poll(
-        () =>
-          mintButton
-            .isEnabled()
-            .then(() => true)
-            .catch(() => false),
-        { timeout: 15000 }
-      )
+      .poll(() => mintButton.isEnabled().catch(() => false), { timeout: 15000 })
       .toBeTruthy();
     await mintButton.click();
 
@@ -136,14 +129,7 @@ test.describe('Mint Assets', () => {
 
     const mintButton = getButtonByText(page, 'Mint Asset configuration');
     await expect
-      .poll(
-        () =>
-          mintButton
-            .isEnabled()
-            .then(() => true)
-            .catch(() => false),
-        { timeout: 15000 }
-      )
+      .poll(() => mintButton.isEnabled().catch(() => false), { timeout: 15000 })
       .toBeTruthy();
     await mintButton.click();
 

--- a/packages/e2e-contract-tests/playwright/e2e/utils/contract.ts
+++ b/packages/e2e-contract-tests/playwright/e2e/utils/contract.ts
@@ -1,5 +1,10 @@
 import type { FuelWalletTestHelper } from '@fuels/playwright-utils';
-import { getButtonByText, getByAriaLabel } from '@fuels/playwright-utils';
+import {
+  expect,
+  getButtonByText,
+  getByAriaLabel,
+  hasText,
+} from '@fuels/playwright-utils';
 import type { Page } from '@playwright/test';
 
 export const connect = async (
@@ -12,5 +17,13 @@ export const connect = async (
   await getByAriaLabel(page, `Connect to ${walletName}`, true).click();
   await fuelWalletTestHelper.walletConnect();
 
-  await page.waitForTimeout(3000);
+  await expect
+    .poll(
+      () =>
+        hasText(page, 'Status: Connected')
+          .then(() => true)
+          .catch(() => false),
+      { timeout: 15000 }
+    )
+    .toBeTruthy();
 };

--- a/packages/e2e-contract-tests/playwright/e2e/utils/contract.ts
+++ b/packages/e2e-contract-tests/playwright/e2e/utils/contract.ts
@@ -26,4 +26,5 @@ export const connect = async (
       { timeout: 15000 }
     )
     .toBeTruthy();
+  await page.waitForTimeout(3000);
 };

--- a/packages/e2e-contract-tests/src/components/DepositHalfEthCard.tsx
+++ b/packages/e2e-contract-tests/src/components/DepositHalfEthCard.tsx
@@ -3,13 +3,26 @@ import { bn } from 'fuels';
 import { useState } from 'react';
 
 import { depositHalf } from '../contract_interactions';
+import { useAction } from '../hooks/useAction';
 import { useBaseAssetId } from '../hooks/useBaseAssetId';
 
 export const DepositHalfEthCard = () => {
   const [amount, setAmount] = useState<string>('');
   const { account } = useAccount();
-  const wallet = useWallet(account);
+  const wallet = useWallet({ account });
   const baseAssetId = useBaseAssetId();
+  const { disabled, execute, error } = useAction({
+    isValid: !!baseAssetId && !!wallet && !!amount,
+    action: async () => {
+      if (baseAssetId && wallet.wallet && amount) {
+        await depositHalf({
+          wallet: wallet.wallet!,
+          amount: bn.parseUnits(amount),
+          assetId: baseAssetId,
+        });
+      }
+    },
+  });
 
   return (
     <div>
@@ -24,21 +37,10 @@ export const DepositHalfEthCard = () => {
           value={amount}
         />
         <br />
-        <button
-          type="button"
-          disabled={!baseAssetId}
-          onClick={async () => {
-            if (baseAssetId && wallet.wallet && amount) {
-              await depositHalf({
-                wallet: wallet.wallet,
-                amount: bn.parseUnits(amount),
-                assetId: baseAssetId,
-              });
-            }
-          }}
-        >
+        <button type="button" disabled={disabled} onClick={execute}>
           Deposit Half ETH
         </button>
+        {error && <p style={{ color: 'red' }}>{error}</p>}
         <hr />
       </div>
     </div>

--- a/packages/e2e-contract-tests/src/components/ForwardCustomAssetCard.tsx
+++ b/packages/e2e-contract-tests/src/components/ForwardCustomAssetCard.tsx
@@ -4,17 +4,30 @@ import { useState } from 'react';
 
 import { MAIN_CONTRACT_ID } from '../config';
 import { deposit } from '../contract_interactions';
+import { useAction } from '../hooks/useAction';
 import { useBaseAssetId } from '../hooks/useBaseAssetId';
 import { calculateAssetId } from '../utils';
 
 export const ForwardCustomAssetCard = () => {
   const [amount, setAmount] = useState<string>('');
   const { account } = useAccount();
-  const wallet = useWallet(account);
+  const wallet = useWallet({ account });
 
   const baseAssetId = useBaseAssetId();
   const assetId =
     !!baseAssetId && calculateAssetId(MAIN_CONTRACT_ID, baseAssetId);
+  const { disabled, execute, error } = useAction({
+    isValid: !!baseAssetId && !!wallet && !!amount,
+    action: async () => {
+      if (assetId && wallet.wallet && amount) {
+        await deposit({
+          wallet: wallet.wallet!,
+          amount: bn.parseUnits(amount, 1).div(10),
+          assetId,
+        });
+      }
+    },
+  });
 
   return (
     <div>
@@ -27,21 +40,10 @@ export const ForwardCustomAssetCard = () => {
           value={amount}
         />
         <br />
-        <button
-          type="button"
-          disabled={!assetId}
-          onClick={async () => {
-            if (assetId && wallet.wallet && amount) {
-              await deposit({
-                wallet: wallet.wallet,
-                amount: bn.parseUnits(amount, 1).div(10),
-                assetId,
-              });
-            }
-          }}
-        >
+        <button type="button" disabled={disabled} onClick={execute}>
           Forward Custom Asset
         </button>
+        {error && <p style={{ color: 'red' }}>{error}</p>}
         <hr />
       </div>
     </div>

--- a/packages/e2e-contract-tests/src/components/ForwardEthCard.tsx
+++ b/packages/e2e-contract-tests/src/components/ForwardEthCard.tsx
@@ -3,13 +3,25 @@ import { bn } from 'fuels';
 import { useState } from 'react';
 
 import { deposit } from '../contract_interactions';
+import { useAction } from '../hooks/useAction';
 import { useBaseAssetId } from '../hooks/useBaseAssetId';
 
 export const ForwardEthCard = () => {
   const [amount, setAmount] = useState<string>('');
   const { account } = useAccount();
-  const wallet = useWallet(account);
+  const wallet = useWallet({ account });
   const baseAssetId = useBaseAssetId();
+
+  const { disabled, execute, error } = useAction({
+    isValid: !!baseAssetId && !!wallet && !!amount,
+    action: async () => {
+      await deposit({
+        wallet: wallet.wallet!,
+        amount: bn.parseUnits(amount),
+        assetId: baseAssetId,
+      });
+    },
+  });
 
   return (
     <div>
@@ -22,21 +34,10 @@ export const ForwardEthCard = () => {
           value={amount}
         />
         <br />
-        <button
-          type="button"
-          disabled={!baseAssetId}
-          onClick={async () => {
-            if (baseAssetId && wallet.wallet && amount) {
-              await deposit({
-                wallet: wallet.wallet,
-                amount: bn.parseUnits(amount),
-                assetId: baseAssetId,
-              });
-            }
-          }}
-        >
+        <button type="button" disabled={disabled} onClick={execute}>
           Forward ETH
         </button>
+        {error && <p style={{ color: 'red' }}>{error}</p>}
         <hr />
       </div>
     </div>

--- a/packages/e2e-contract-tests/src/components/ForwardHalfAndExternalMintCard.tsx
+++ b/packages/e2e-contract-tests/src/components/ForwardHalfAndExternalMintCard.tsx
@@ -3,14 +3,28 @@ import { bn } from 'fuels';
 import { useState } from 'react';
 
 import { depositHalfAndExternalMint } from '../contract_interactions';
+import { useAction } from '../hooks/useAction';
 import { useBaseAssetId } from '../hooks/useBaseAssetId';
 
 export const ForwardHalfAndExternalMintCard = () => {
   const [forwardAmount, setForwardAmount] = useState<string>('');
   const [mintAmount, setMintAmount] = useState<string>('');
   const { account } = useAccount();
-  const wallet = useWallet(account);
+  const wallet = useWallet({ account });
   const baseAssetId = useBaseAssetId();
+
+  const { disabled, execute, error } = useAction({
+    isValid: !!baseAssetId && !!wallet && !!forwardAmount && !!mintAmount,
+    action: async () => {
+      await depositHalfAndExternalMint({
+        wallet: wallet.wallet!,
+        forwardAmount: bn.parseUnits(forwardAmount),
+        mintAmount: bn.parseUnits(mintAmount, 1).div(10),
+        assetId: baseAssetId,
+        baseAssetId,
+      });
+    },
+  });
 
   return (
     <div>
@@ -32,23 +46,10 @@ export const ForwardHalfAndExternalMintCard = () => {
           value={mintAmount}
         />
         <br />
-        <button
-          type="button"
-          disabled={!baseAssetId}
-          onClick={async () => {
-            if (baseAssetId && wallet.wallet && mintAmount && forwardAmount) {
-              await depositHalfAndExternalMint({
-                wallet: wallet.wallet,
-                forwardAmount: bn.parseUnits(forwardAmount),
-                mintAmount: bn.parseUnits(mintAmount, 1).div(10),
-                assetId: baseAssetId,
-                baseAssetId,
-              });
-            }
-          }}
-        >
+        <button type="button" disabled={disabled} onClick={execute}>
           Forward Half And External Mint
         </button>
+        {error && <p style={{ color: 'red' }}>{error}</p>}
         <hr />
       </div>
     </div>

--- a/packages/e2e-contract-tests/src/components/ForwardHalfCustomAssetCard.tsx
+++ b/packages/e2e-contract-tests/src/components/ForwardHalfCustomAssetCard.tsx
@@ -4,15 +4,28 @@ import { useState } from 'react';
 
 import { MAIN_CONTRACT_ID } from '../config';
 import { depositHalf } from '../contract_interactions';
+import { useAction } from '../hooks/useAction';
 import { useBaseAssetId } from '../hooks/useBaseAssetId';
 import { calculateAssetId } from '../utils';
 
 export const ForwardHalfCustomAssetCard = () => {
   const [amount, setAmount] = useState<string>('');
   const { account } = useAccount();
-  const wallet = useWallet(account);
+  const wallet = useWallet({ account });
 
   const baseAssetId = useBaseAssetId();
+  const { disabled, execute, error } = useAction({
+    isValid: !!baseAssetId && !!wallet && !!amount,
+    action: async () => {
+      if (assetId && wallet.wallet && amount) {
+        await depositHalf({
+          wallet: wallet.wallet!,
+          amount: bn.parseUnits(amount, 1).div(10),
+          assetId,
+        });
+      }
+    },
+  });
 
   const assetId =
     !!baseAssetId && calculateAssetId(MAIN_CONTRACT_ID, baseAssetId);
@@ -28,21 +41,10 @@ export const ForwardHalfCustomAssetCard = () => {
           value={amount}
         />
         <br />
-        <button
-          type="button"
-          disabled={!baseAssetId}
-          onClick={async () => {
-            if (assetId && wallet.wallet && amount) {
-              await depositHalf({
-                wallet: wallet.wallet,
-                amount: bn.parseUnits(amount, 1).div(10),
-                assetId,
-              });
-            }
-          }}
-        >
+        <button type="button" disabled={disabled} onClick={execute}>
           Forward Half Custom Asset
         </button>
+        {error && <p style={{ color: 'red' }}>{error}</p>}
         <hr />
       </div>
     </div>

--- a/packages/e2e-contract-tests/src/components/Header.tsx
+++ b/packages/e2e-contract-tests/src/components/Header.tsx
@@ -1,11 +1,14 @@
 import { useConnectUI } from '@fuels/react';
 
 export const Header = () => {
-  const { connect } = useConnectUI();
+  const { connect, isConnected } = useConnectUI();
 
   return (
-    <button type="button" onClick={connect}>
-      Connect
-    </button>
+    <>
+      <button type="button" onClick={connect}>
+        {isConnected ? 'Reconnect' : 'Connect'}
+      </button>
+      <p>Status: {isConnected ? 'Connected' : 'Disconnected'}</p>
+    </>
   );
 };

--- a/packages/e2e-contract-tests/src/components/MintAssetCard.tsx
+++ b/packages/e2e-contract-tests/src/components/MintAssetCard.tsx
@@ -3,13 +3,25 @@ import { bn } from 'fuels';
 import { useState } from 'react';
 
 import { mint } from '../contract_interactions';
+import { useAction } from '../hooks/useAction';
 import { useBaseAssetId } from '../hooks/useBaseAssetId';
 
 export const MintAssetCard = () => {
   const [amount, setAmount] = useState<string>('');
   const { account } = useAccount();
-  const { wallet } = useWallet(account);
+  const { wallet } = useWallet({ account });
   const baseAssetId = useBaseAssetId();
+
+  const { disabled, execute, error } = useAction({
+    isValid: !!baseAssetId && !!wallet && !!amount,
+    action: async () => {
+      await mint({
+        wallet: wallet!,
+        amount: bn.parseUnits(amount, 1).div(10),
+        subId: baseAssetId,
+      });
+    },
+  });
 
   return (
     <div>
@@ -24,21 +36,10 @@ export const MintAssetCard = () => {
           value={amount}
         />
         <br />
-        <button
-          type="button"
-          disabled={!baseAssetId}
-          onClick={async () => {
-            if (baseAssetId && wallet && amount) {
-              await mint({
-                wallet,
-                amount: bn.parseUnits(amount, 1).div(10),
-                subId: baseAssetId,
-              });
-            }
-          }}
-        >
+        <button type="button" disabled={disabled} onClick={execute}>
           Mint
         </button>
+        {error && <p style={{ color: 'red' }}>{error}</p>}
         <hr />
       </div>
     </div>

--- a/packages/e2e-contract-tests/src/hooks/useAction.ts
+++ b/packages/e2e-contract-tests/src/hooks/useAction.ts
@@ -1,0 +1,32 @@
+import { useCallback, useState } from 'react';
+
+type UseActionParams = {
+  isValid: boolean;
+  action: () => Promise<void>;
+};
+
+export const useAction = ({ isValid, action }: UseActionParams) => {
+  const [error, setError] = useState<string | null>(null);
+  const [isExecuting, setIsExecuting] = useState<boolean>(false);
+
+  const execute = useCallback(async () => {
+    if (!isValid) return;
+    setIsExecuting(true);
+    setError(null);
+    try {
+      await action();
+    } catch (err) {
+      setError(
+        (err as Error | undefined)?.message || 'An unexpected error occurred.'
+      );
+    } finally {
+      setIsExecuting(false);
+    }
+  }, [isValid, action]);
+
+  return {
+    disabled: !isValid || isExecuting,
+    execute,
+    error,
+  };
+};


### PR DESCRIPTION
- Contract tests now display:
  - Connection status
  - Contract call errors below each field
 - Buttons are now disabled when required data is not present
 - Replaced `timeouts` with `expect.poll` using new visual indicators