### PR TITLE
fix: preventing wallet to reset because of fetch account returning undefined

### DIFF
--- a/.changeset/lucky-trainers-heal.md
+++ b/.changeset/lucky-trainers-heal.md
@@ -1,0 +1,5 @@
+---
+"fuels-wallet": patch
+---
+
+fix wallet reset when fetch account returns undefined

--- a/packages/app/src/systems/Account/machines/accountsMachine.tsx
+++ b/packages/app/src/systems/Account/machines/accountsMachine.tsx
@@ -50,7 +50,7 @@ const fetchAccount = {
       },
       {
         target: 'idle',
-        actions: ['assignAccount', 'setIsUnlogged'],
+        actions: ['assignAccount'],
       },
     ],
     onError: [
@@ -106,7 +106,7 @@ export const accountsMachine = createMachine(
             },
             {
               target: 'idle',
-              actions: ['assignAccounts', 'setIsUnlogged'],
+              actions: ['assignAccounts'],
             },
           ],
           onError: [
@@ -211,9 +211,6 @@ export const accountsMachine = createMachine(
       setIsLogged: () => {
         Storage.setItem(IS_LOGGED_KEY, true);
       },
-      setIsUnlogged: () => {
-        Storage.removeItem(IS_LOGGED_KEY);
-      },
       notifyUpdateAccounts: () => {
         store.updateAccounts();
       },
@@ -232,7 +229,11 @@ export const accountsMachine = createMachine(
         showError: true,
         maxAttempts: 1,
         async fetch() {
-          const accountToFetch = await AccountService.getCurrentAccount();
+          let accountToFetch = await AccountService.getCurrentAccount();
+          if (!accountToFetch) {
+            await AccountService.setCurrentAccountToDefault();
+            accountToFetch = await AccountService.getCurrentAccount();
+          }
           if (!accountToFetch) return undefined;
           const selectedNetwork = await NetworkService.getSelectedNetwork();
           if (!selectedNetwork) {

--- a/packages/app/src/systems/Account/services/account.ts
+++ b/packages/app/src/systems/Account/services/account.ts
@@ -186,6 +186,26 @@ export class AccountService {
     });
   }
 
+  static setCurrentAccountToFalse() {
+    return db.transaction('rw', db.accounts, async () => {
+      await db.accounts
+        .filter((account) => !!account.isCurrent)
+        .modify({ isCurrent: false });
+    });
+  }
+
+  static setCurrentAccountToDefault() {
+    console.log('recovering default');
+    return db.transaction('rw', db.accounts, async () => {
+      const [firstAccount] = await db.accounts.toArray();
+      if (firstAccount) {
+        await db.accounts
+          .filter((account) => account.address === firstAccount.address)
+          .modify({ isCurrent: true });
+      }
+    });
+  }
+
   static setCurrentAccount(input: AccountInputs['setCurrentAccount']) {
     return db.transaction('rw', db.accounts, async () => {
       await db.accounts


### PR DESCRIPTION
- Closes: [#1666 ](https://linear.app/fuel-network/issue/FE-960/wallet-resetting-issue)

before

https://github.com/user-attachments/assets/f05c6721-6bb6-49b8-a30e-90f2101bba9a

after

https://github.com/user-attachments/assets/30989269-533d-4911-a540-845be34bdbc3

