### PR TITLE
feat: add contract info display for testnet contracts

### DIFF
--- a/packages/app/src/systems/Transaction/components/TxContractHeader/TxContractHeader.tsx
+++ b/packages/app/src/systems/Transaction/components/TxContractHeader/TxContractHeader.tsx
@@ -1,0 +1,66 @@
+import { cssObj } from '@fuel-ui/css';
+import { Avatar, Box } from '@fuel-ui/react';
+import { AddressType, OperationName } from 'fuels';
+import type { Operation } from 'fuels';
+import { useEffect, useState } from 'react';
+import { getContractInfo } from '../../utils/getContractInfo';
+
+type Props = {
+  operations?: Operation[];
+  title?: string;
+};
+
+export function TxContractHeader({ operations, title }: Props) {
+  const [contractInfo, setContractInfo] = useState<{
+    name: string;
+    image: string;
+  } | null>(null);
+
+  useEffect(() => {
+    async function fetchContractInfo() {
+      if (!operations?.length) return;
+
+      // Log operations for debugging
+      console.log('Operations:', operations);
+
+      const contractOp = operations.find((op) => {
+        const isContractType = op.to?.type === AddressType.contract;
+        const isContractCall = op.name === OperationName.contractCall;
+        const isContractCreated = op.name === OperationName.contractCreated;
+
+        return isContractType || isContractCall || isContractCreated;
+      });
+
+      if (contractOp?.to?.address) {
+        const info = await getContractInfo(contractOp.to.address);
+        console.log('Contract info:', info); // Debug log
+        if (info) setContractInfo(info);
+      }
+    }
+
+    fetchContractInfo();
+  }, [operations]);
+
+  const displayName = contractInfo?.name || title || 'Transaction';
+  const displayImage = contractInfo?.image;
+
+  return (
+    <Box.Flex css={styles.contractHeader}>
+      <Avatar size="sm" src={displayImage} name={displayName} />
+      <span>{displayName}</span>
+    </Box.Flex>
+  );
+}
+
+const styles = {
+  contractHeader: cssObj({
+    display: 'flex',
+    alignItems: 'center',
+    gap: '$2',
+
+    '& span': {
+      fontSize: '$sm',
+      fontWeight: '$medium',
+    },
+  }),
+};

--- a/packages/app/src/systems/Transaction/components/TxContractHeader/TxContractHeader.tsx
+++ b/packages/app/src/systems/Transaction/components/TxContractHeader/TxContractHeader.tsx
@@ -2,8 +2,7 @@ import { cssObj } from '@fuel-ui/css';
 import { Avatar, Box } from '@fuel-ui/react';
 import { AddressType, OperationName } from 'fuels';
 import type { Operation } from 'fuels';
-import { useEffect, useState } from 'react';
-import { getContractInfo } from '../../utils/getContractInfo';
+import { useContractInfo } from '../../hooks/useContractInfo';
 
 type Props = {
   operations?: Operation[];
@@ -11,35 +10,14 @@ type Props = {
 };
 
 export function TxContractHeader({ operations, title }: Props) {
-  const [contractInfo, setContractInfo] = useState<{
-    name: string;
-    image: string;
-  } | null>(null);
+  const contractOp = operations?.find((op) => {
+    const isContractType = op.to?.type === AddressType.contract;
+    const isContractCall = op.name === OperationName.contractCall;
+    const isContractCreated = op.name === OperationName.contractCreated;
+    return isContractType || isContractCall || isContractCreated;
+  });
 
-  useEffect(() => {
-    async function fetchContractInfo() {
-      if (!operations?.length) return;
-
-      // Log operations for debugging
-      console.log('Operations:', operations);
-
-      const contractOp = operations.find((op) => {
-        const isContractType = op.to?.type === AddressType.contract;
-        const isContractCall = op.name === OperationName.contractCall;
-        const isContractCreated = op.name === OperationName.contractCreated;
-
-        return isContractType || isContractCall || isContractCreated;
-      });
-
-      if (contractOp?.to?.address) {
-        const info = await getContractInfo(contractOp.to.address);
-        console.log('Contract info:', info); // Debug log
-        if (info) setContractInfo(info);
-      }
-    }
-
-    fetchContractInfo();
-  }, [operations]);
+  const { contractInfo } = useContractInfo(contractOp?.to?.address);
 
   const displayName = contractInfo?.name || title || 'Transaction';
   const displayImage = contractInfo?.image;

--- a/packages/app/src/systems/Transaction/hooks/useContractInfo.ts
+++ b/packages/app/src/systems/Transaction/hooks/useContractInfo.ts
@@ -1,0 +1,30 @@
+import { useEffect, useState } from 'react';
+import { getContractInfo } from '../utils/getContractInfo';
+import type { ContractInfo } from '../utils/getContractInfo';
+
+export function useContractInfo(contractId?: string) {
+  const [contractInfo, setContractInfo] = useState<ContractInfo | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    async function fetchContractInfo() {
+      if (!contractId) return;
+
+      setIsLoading(true);
+      try {
+        const info = await getContractInfo(contractId);
+        setContractInfo(info);
+      } catch (err) {
+        setError(err as Error);
+        console.error('Error fetching contract info:', err);
+      } finally {
+        setIsLoading(false);
+      }
+    }
+
+    fetchContractInfo();
+  }, [contractId]);
+
+  return { contractInfo, isLoading, error };
+}

--- a/packages/app/src/systems/Transaction/pages/TxApprove/TxApprove.tsx
+++ b/packages/app/src/systems/Transaction/pages/TxApprove/TxApprove.tsx
@@ -9,6 +9,7 @@ import { coreStyles } from '~/systems/Core/styles';
 import { useTransactionRequest } from '~/systems/DApp';
 import { OverlayDialogTopbar } from '~/systems/Overlay';
 import { TxContent } from '~/systems/Transaction';
+import { TxContractHeader } from '../../components/TxContractHeader/TxContractHeader';
 import { getContractInfo } from '../../utils/getContractInfo';
 
 export const TxApprove = () => {
@@ -18,7 +19,7 @@ export const TxApprove = () => {
   const isSuccess = ctx.status('success');
   const isLoading =
     ctx.status('loading') || ctx.status('sending') || isLoadingAssets;
-  const [contractInfo, setContractInfo] = useState<{
+  const [_contractInfo, setContractInfo] = useState<{
     name: string;
     image: string;
   } | null>(null);
@@ -44,14 +45,10 @@ export const TxApprove = () => {
       <OverlayDialogTopbar
         onClose={isSuccess ? goToWallet : ctx.handlers.closeDialog}
       >
-        <Box.Flex css={styles.contractHeader}>
-          <Avatar
-            size="sm"
-            src={contractInfo?.image}
-            name={contractInfo?.name || 'Unknown Contract'}
-          />
-          <span>{contractInfo?.name || ctx.title}</span>
-        </Box.Flex>
+        <TxContractHeader
+          operations={ctx.txSummarySimulated?.operations}
+          title={ctx.title}
+        />
       </OverlayDialogTopbar>
       <Dialog.Description as="div" css={styles.description}>
         {!ctx.txSummarySimulated && <TxContent.Loader />}

--- a/packages/app/src/systems/Transaction/utils/getContractInfo.ts
+++ b/packages/app/src/systems/Transaction/utils/getContractInfo.ts
@@ -1,0 +1,58 @@
+interface ContractInfo {
+  name: string;
+  image: string;
+  description: string;
+}
+
+interface Contract {
+  id: string;
+  name: string;
+  description?: string;
+}
+
+interface Project {
+  name: string;
+  image: string;
+  description: string;
+  contracts?: {
+    mainnet?: Contract[];
+    sepolia?: Contract[];
+  };
+}
+
+const PROJECTS_URL = 'https://fuellabs.github.io/fuel-ecosystem/projects.json';
+const projectsCache: Project[] | null = null;
+
+export async function getContractInfo(
+  contractId: string
+): Promise<ContractInfo | null> {
+  try {
+    if (!projectsCache) {
+      const response = await fetch(PROJECTS_URL);
+      const projects = (await response.json()) as Project[];
+
+      for (const project of projects) {
+        const contracts = [
+          ...(project.contracts?.mainnet || []),
+          ...(project.contracts?.sepolia || []),
+        ];
+
+        const matchingContract = contracts.find(
+          (contract) => contract.id.toLowerCase() === contractId.toLowerCase()
+        );
+
+        if (matchingContract) {
+          return {
+            name: matchingContract.name,
+            image: `https://raw.githubusercontent.com/FuelLabs/fuel-ecosystem/main/packages/registry/public/logos/${project.image}.png`,
+            description: matchingContract.description || project.description,
+          };
+        }
+      }
+    }
+    return null;
+  } catch (error) {
+    console.error('Error fetching contract info:', error);
+    return null;
+  }
+}

--- a/packages/app/src/systems/Transaction/utils/getContractInfo.ts
+++ b/packages/app/src/systems/Transaction/utils/getContractInfo.ts
@@ -21,33 +21,33 @@ interface Project {
 }
 
 const PROJECTS_URL = 'https://fuellabs.github.io/fuel-ecosystem/projects.json';
-const projectsCache: Project[] | null = null;
+let projectsCache: Project[] | undefined;
 
 export async function getContractInfo(
   contractId: string
 ): Promise<ContractInfo | null> {
   try {
-    if (!projectsCache) {
+    if (projectsCache === undefined) {
       const response = await fetch(PROJECTS_URL);
-      const projects = (await response.json()) as Project[];
+      projectsCache = (await response.json()) as Project[];
+    }
 
-      for (const project of projects) {
-        const contracts = [
-          ...(project.contracts?.mainnet || []),
-          ...(project.contracts?.sepolia || []),
-        ];
+    for (const project of projectsCache) {
+      const contracts = [
+        ...(project.contracts?.mainnet || []),
+        ...(project.contracts?.sepolia || []),
+      ];
 
-        const matchingContract = contracts.find(
-          (contract) => contract.id.toLowerCase() === contractId.toLowerCase()
-        );
+      const matchingContract = contracts.find(
+        (contract) => contract.id.toLowerCase() === contractId.toLowerCase()
+      );
 
-        if (matchingContract) {
-          return {
-            name: matchingContract.name,
-            image: `https://raw.githubusercontent.com/FuelLabs/fuel-ecosystem/main/packages/registry/public/logos/${project.image}.png`,
-            description: matchingContract.description || project.description,
-          };
-        }
+      if (matchingContract) {
+        return {
+          name: matchingContract.name,
+          image: `https://raw.githubusercontent.com/FuelLabs/fuel-ecosystem/main/packages/registry/public/logos/${project.image}.png`,
+          description: matchingContract.description || project.description,
+        };
       }
     }
     return null;

--- a/packages/app/src/systems/Transaction/utils/getContractInfo.ts
+++ b/packages/app/src/systems/Transaction/utils/getContractInfo.ts
@@ -1,4 +1,4 @@
-interface ContractInfo {
+export interface ContractInfo {
   name: string;
   image: string;
   description: string;
@@ -27,8 +27,13 @@ export async function getContractInfo(
   contractId: string
 ): Promise<ContractInfo | null> {
   try {
+    console.log('Fetching contract info for:', contractId);
+
     if (projectsCache === undefined) {
       const response = await fetch(PROJECTS_URL);
+      if (!response.ok) {
+        throw new Error(`Failed to fetch projects: ${response.statusText}`);
+      }
       projectsCache = (await response.json()) as Project[];
     }
 
@@ -43,6 +48,7 @@ export async function getContractInfo(
       );
 
       if (matchingContract) {
+        console.log('Found contract:', matchingContract);
         return {
           name: matchingContract.name,
           image: `https://raw.githubusercontent.com/FuelLabs/fuel-ecosystem/main/packages/registry/public/logos/${project.image}.png`,
@@ -50,6 +56,8 @@ export async function getContractInfo(
         };
       }
     }
+
+    console.log('No contract info found for:', contractId);
     return null;
   } catch (error) {
     console.error('Error fetching contract info:', error);


### PR DESCRIPTION
- Add support for displaying contract names and logos in transaction approval screen
- Support both mainnet and testnet (sepolia) contracts
- Fetch contract info from fuel-ecosystem registry