### PR TITLE
fix: wallet reset issue

### DIFF
--- a/.changeset/brown-walls-rescue.md
+++ b/.changeset/brown-walls-rescue.md
@@ -1,0 +1,5 @@
+---
+"fuels-wallet": patch
+---
+
+refactor: accountMachine should not handle isLogged operations and should not have parallel states running

--- a/.changeset/cool-goats-teach.md
+++ b/.changeset/cool-goats-teach.md
@@ -1,0 +1,5 @@
+---
+"fuels-wallet": patch
+---
+
+set isLogged when opening the db

--- a/.changeset/sharp-beans-exist.md
+++ b/.changeset/sharp-beans-exist.md
@@ -1,0 +1,5 @@
+---
+"fuels-wallet": patch
+---
+
+feat: cleaning now waits for localStorage

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,6 @@
 {
   "recommendations": [
     "FuelLabs.sway-vscode-plugin",
-    "statelyai.stately-vscode",
-    "firsttris.vscode-jest-runner"
+    "statelyai.stately-vscode"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,5 +9,10 @@
   },
   "[typescript]": {
     "editor.defaultFormatter": "biomejs.biome"
-  }
+  },
+  "typescript.suggest.autoImports": true,
+  "javascript.suggest.autoImports": true,
+  "typescript.suggest.paths": true,
+  "typescript.suggest.enabled": true,
+  "typescript.suggest.completeFunctionCalls": true,
 }

--- a/packages/app/src/systems/Account/hooks/useAccounts.tsx
+++ b/packages/app/src/systems/Account/hooks/useAccounts.tsx
@@ -81,14 +81,6 @@ export function useAccounts() {
     return accountStatus === status;
   }
 
-  store.useUpdateMachineConfig(Services.accounts, {
-    actions: {
-      refreshApplication() {
-        window.location.reload();
-      },
-    },
-  });
-
   useEffect(() => {
     if (shouldListen.current) {
       shouldListen.current = false;

--- a/packages/app/src/systems/Account/services/account.ts
+++ b/packages/app/src/systems/Account/services/account.ts
@@ -261,7 +261,9 @@ export class AccountService {
         // biome-ignore lint/suspicious/noExplicitAny: <explanation>
         const dataToLog: any = {};
         try {
-          dataToLog.backupAccounts = JSON.stringify(backupAccounts?.map((account) => account?.data?.address) || []);
+          dataToLog.backupAccounts = JSON.stringify(
+            backupAccounts?.map((account) => account?.data?.address) || []
+          );
           dataToLog.backupNetworks = JSON.stringify(backupNetworks || []);
           // try getting data from indexedDB (outside of dexie) to check if it's also corrupted
           const testNoDexieDbData = await getTestNoDexieDbData();

--- a/packages/app/src/systems/Account/utils/storage.tsx
+++ b/packages/app/src/systems/Account/utils/storage.tsx
@@ -28,8 +28,6 @@ export class IndexedDBStorage implements StorageAbstract {
   }
 
   async clear() {
-    await chromeStorage.vaults.clear();
-    await chromeStorage.accounts.clear();
     await db.transaction('rw', db.vaults, db.accounts, async () => {
       await db.vaults.clear();
       await db.accounts.clear();

--- a/packages/app/src/systems/Core/services/core.ts
+++ b/packages/app/src/systems/Core/services/core.ts
@@ -1,18 +1,26 @@
-import { toast } from '@fuel-ui/react';
 import { VaultService } from '~/systems/Vault';
-import { delay } from '../utils';
 import { db } from '../utils/database';
 import { Storage } from '../utils/storage';
 import { chromeStorage } from './chromeStorage';
+import { clearParallelDb } from '~/systems/Core/utils/databaseNoDexie';
+import { IS_LOGGED_KEY } from '~/config';
 
 // biome-ignore lint/complexity/noStaticOnlyClass: <explanation>
 export class CoreService {
   static async clear() {
-    toast.success('Your wallet will be reset');
-    await delay(1500);
     await chromeStorage.clear();
     await VaultService.clear();
     await db.clear();
-    await Storage.clear();
+    Storage.clear();
+    await clearParallelDb();
+    const reloadAfterCleanCompleted = () => {
+      const isLogged = Storage.getItem(IS_LOGGED_KEY);
+      if (!isLogged) {
+        window.location.reload();
+        return;
+      }
+      setTimeout(() => reloadAfterCleanCompleted(), 50);
+    };
+    reloadAfterCleanCompleted();
   }
 }

--- a/packages/app/src/systems/Core/utils/databaseNoDexie.ts
+++ b/packages/app/src/systems/Core/utils/databaseNoDexie.ts
@@ -1,0 +1,28 @@
+export const createParallelDb = async () => {
+  // add table outside of dexie to test if it will be corrupted also with dexie FuelDB
+  if (typeof window !== 'undefined') {
+    const request = await window.indexedDB.open('TestDatabase', 2);
+    request.onupgradeneeded = (event) => {
+      const db = (event.target as IDBRequest)?.result;
+      db.createObjectStore('myTable', { keyPath: 'id' });
+    };
+    request.onsuccess = (event: Event) => {
+      const db = (event.target as IDBRequest).result as IDBDatabase;
+      const tx = db.transaction('myTable', 'readwrite');
+      const store = tx.objectStore('myTable');
+
+      const countRequest = store.count();
+      countRequest.onsuccess = () => {
+        if (countRequest.result === 0) {
+          store.add({ id: 1, name: 'John' });
+        }
+      };
+    };
+  }
+};
+
+export const clearParallelDb = async () => {
+  if (typeof window !== 'undefined') {
+    await window.indexedDB.deleteDatabase('TestDatabase');
+  }
+};


### PR DESCRIPTION
- Closes FE-1148

- refactor `accountMachine`
  - should not have parallel states running between logout / fetchAccounts
  - should have NOTHING to do with local storage prop `isLogged`
- move page reload to clear service, eliminating the possibility of anything running after it
- clear method wait for localStorage to be clean before reload
- now `isLogged` is set when opening the db
