### PR TITLE
Typo fix in CHANGELOG.md

### DIFF
--- a/packages/app/CHANGELOG.md
+++ b/packages/app/CHANGELOG.md
@@ -679,7 +679,7 @@
 
 ### Minor Changes
 
-- [#1397](https://github.com/FuelLabs/fuels-wallet/pull/1397) [`3966aa92`](https://github.com/FuelLabs/fuels-wallet/commit/3966aa929608520869486043e633a32156d93c19) Thanks [@rodrigobranas](https://github.com/rodrigobranas)! - Improved error handling and including location informations to support better understanding about the causes of erros
+- [#1397](https://github.com/FuelLabs/fuels-wallet/pull/1397) [`3966aa92`](https://github.com/FuelLabs/fuels-wallet/commit/3966aa929608520869486043e633a32156d93c19) Thanks [@rodrigobranas](https://github.com/rodrigobranas)! - Improved error handling and including location informations to support better understanding about the causes of errors
 
 - [#1385](https://github.com/FuelLabs/fuels-wallet/pull/1385) [`d49b9efe`](https://github.com/FuelLabs/fuels-wallet/commit/d49b9efe8b3133b67d748cc7a7dc3b0f506555f1) Thanks [@rodrigobranas](https://github.com/rodrigobranas)! - Support for Bech32 addresses has been removed and replaced with b256 (hex) addresses throughout the wallet screen components. All addresses, both existing and new, will now be displayed in the b256 format.
 


### PR DESCRIPTION
# Title:
Fix Typo in `CHANGELOG.md`

# Description:
This pull request corrects a typographical error in the `CHANGELOG.md` file, where "erros" was incorrectly used instead of "errors."

# Changes:
- Replaced "erros" with "errors" for improved clarity and professionalism.

