### PR TITLE
Typo fix in CHANGELOG.md

### DIFF
--- a/packages/app/CHANGELOG.md
+++ b/packages/app/CHANGELOG.md
@@ -984,7 +984,7 @@
 
 - [#1043](https://github.com/FuelLabs/fuels-wallet/pull/1043) [`1bf46d6`](https://github.com/FuelLabs/fuels-wallet/commit/1bf46d63ec2ffa3d571a1bc0350955ca2b54f645) Thanks [@matt-user](https://github.com/matt-user)! - Throw an error when asset name is undefined
 
-- [#1048](https://github.com/FuelLabs/fuels-wallet/pull/1048) [`f010e4e`](https://github.com/FuelLabs/fuels-wallet/commit/f010e4ec21c32120cc464d27b31d3eb6b044754e) Thanks [@luizstacio](https://github.com/luizstacio)! - Update fuel-ui pacakge
+- [#1048](https://github.com/FuelLabs/fuels-wallet/pull/1048) [`f010e4e`](https://github.com/FuelLabs/fuels-wallet/commit/f010e4ec21c32120cc464d27b31d3eb6b044754e) Thanks [@luizstacio](https://github.com/luizstacio)! - Update fuel-ui package
 
 - Updated dependencies []:
   - @fuel-wallet/sdk@0.14.2


### PR DESCRIPTION
# Pull Request: Typo Fix - "pacakge" to "package"

## Description

This pull request addresses a typo where "pacakge" was incorrectly used instead of "package." The correction ensures consistency and professionalism in the documentation or code.

## Changes Made

- Replaced instances of "pacakge" with "package" in the affected file(s).

