### PR TITLE
chore: fix typo  CHANGELOG.md

### DIFF
--- a/packages/app/CHANGELOG.md
+++ b/packages/app/CHANGELOG.md
@@ -1010,7 +1010,7 @@
 
 ### Patch Changes
 
-- [#1034](https://github.com/FuelLabs/fuels-wallet/pull/1034) [`020dc09`](https://github.com/FuelLabs/fuels-wallet/commit/020dc09150dbc67b3b8274365162edf29542082d) Thanks [@luizstacio](https://github.com/luizstacio)! - Clean assets from database when reseting wallet
+- [#1034](https://github.com/FuelLabs/fuels-wallet/pull/1034) [`020dc09`](https://github.com/FuelLabs/fuels-wallet/commit/020dc09150dbc67b3b8274365162edf29542082d) Thanks [@luizstacio](https://github.com/luizstacio)! - Clean assets from database when resetting wallet
 
 - Updated dependencies [[`9458253`](https://github.com/FuelLabs/fuels-wallet/commit/94582534fb7303d88ef2523c54ae3d336ab693a8)]:
   - @fuel-wallet/types@0.14.0


### PR DESCRIPTION
# chore: Fix Typo in `CHANGELOG.md`

## Description
This pull request fixes a typo in the `CHANGELOG.md` file by correcting "reseting" to "resetting," improving documentation clarity and consistency.

