### PR TITLE
ci: refactor release workflow to separate changeset and publish jobs

### DIFF
--- a/.github/workflows/release-npm-changeset.yaml
+++ b/.github/workflows/release-npm-changeset.yaml
@@ -128,6 +128,8 @@ jobs:
         if: steps.changesets.outputs.published == 'true'
         run: pnpm build:crx
         env:
+          ## increase node.js m memory limit for building
+          ## with sourcemaps
           NODE_OPTIONS: "--max-old-space-size=4096"
 
       - name: Build Fuel Wallet Development

--- a/.github/workflows/release-npm-changeset.yaml
+++ b/.github/workflows/release-npm-changeset.yaml
@@ -71,7 +71,7 @@ jobs:
           git config --global user.email "${{ github.actor }}@users.noreply.github.com"
 
       - name: Create Changeset PR
-        uses: FuelLabs/changesets-action@v2.0.0
+        uses: changesets/action@v1
         with:
           commit: "ci(changesets): versioning packages"
           title: "ci(changesets): versioning packages"

--- a/.github/workflows/release-npm-changeset.yaml
+++ b/.github/workflows/release-npm-changeset.yaml
@@ -71,7 +71,7 @@ jobs:
           git config --global user.email "${{ github.actor }}@users.noreply.github.com"
 
       - name: Create Changeset PR
-        uses: changesets/action@v1
+        uses: FuelLabs/changesets-action@v2.0.0
         with:
           commit: "ci(changesets): versioning packages"
           title: "ci(changesets): versioning packages"

--- a/.github/workflows/release-npm-changeset.yaml
+++ b/.github/workflows/release-npm-changeset.yaml
@@ -122,7 +122,7 @@ jobs:
           version: pnpm changeset version
         env:
           GITHUB_TOKEN: ${{ secrets.REPO_TOKEN }}
-          NPM_TOKEN_WALLET: ${{ secrets.NPM_TOKEN_WALLET }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN_WALLET }}
 
       - name: Build Fuel Wallet
         if: steps.changesets.outputs.published == 'true'

--- a/.github/workflows/release-npm-changeset.yaml
+++ b/.github/workflows/release-npm-changeset.yaml
@@ -13,8 +13,35 @@ env:
   BUILD_VERSION: ""
 
 jobs:
-  release-changesets:
+  check-commit:
     name: Release master or rc
+    runs-on: buildjet-4vcpu-ubuntu-2204
+    outputs:
+      is_changeset_pr: ${{ steps.check-commit.outputs.is_changeset_pr }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check if merge from changeset PR
+        id: check-commit
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [[ "${{ github.event.head_commit.message }}" == "Merge pull request"* ]]; then
+            PR_NUMBER=$(echo "${{ github.event.head_commit.message }}" | grep -o '#[0-9]\+' | tr -d '#')
+            if [ ! -z "$PR_NUMBER" ]; then
+              PR_TITLE=$(gh pr view $PR_NUMBER --json title -q .title)
+              if [[ "$PR_TITLE" == "ci(changesets): versioning packages" ]]; then
+                echo "is_changeset_pr=true" >> $GITHUB_OUTPUT
+                exit 0
+              fi
+            fi
+          fi
+          echo "is_changeset_pr=false" >> $GITHUB_OUTPUT
+
+  create-pr:
+    needs: check-commit
+    if: needs.check-commit.outputs.is_changeset_pr == 'false'
     runs-on: buildjet-4vcpu-ubuntu-2204
     environment: npm-deploy
     steps:
@@ -38,6 +65,43 @@ jobs:
         with:
           npm-token: ${{ secrets.NPM_TOKEN_WALLET }}
 
+      - name: Setup git user (for changelog step)
+        run: |
+          git config --global user.name "${{ github.actor }}"
+          git config --global user.email "${{ github.actor }}@users.noreply.github.com"
+
+      - name: Create Changeset PR
+        uses: changesets/action@v1
+        with:
+          commit: "ci(changesets): versioning packages"
+          title: "ci(changesets): versioning packages"
+          createGithubReleases: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.REPO_TOKEN }}
+
+  publish-npm:
+    needs: check-commit
+    if: needs.check-commit.outputs.is_changeset_pr == 'true'
+    runs-on: ubuntu-latest
+    environment: npm-deploy
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Extract pnpm version from .tool-versions
+        id: get_pnpm
+        run: |
+          PNPM_VERSION=$(grep '^pnpm' .tool-versions | awk '{print $2}')
+          echo "PNPM_VERSION=${PNPM_VERSION}" >> $GITHUB_ENV
+      - uses: FuelLabs/github-actions/setups/node@master
+        with:
+          node-version: 20.11.0
+          pnpm-version: ${{  env.PNPM_VERSION }}
+      - uses: FuelLabs/github-actions/setups/npm@master
+        with:
+          npm-token: ${{ secrets.NPM_TOKEN_WALLET }}
+
       - name: Bump and Collect Version
         run: |
           pnpm changeset version
@@ -46,34 +110,24 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Setup git user (for changelog step)
-        run: |
-          git config --global user.name "${{ github.actor }}"
-          git config --global user.email "${{ github.actor }}@users.noreply.github.com"
-
       - name: Build packages
         run: pnpm build:libs
 
-      - name: Create Release Pull Request or Publish to NPM
+      - name: Publish to NPM
         id: changesets
         uses: FuelLabs/changesets-action@v2.0.0
         with:
           publish: pnpm changeset publish --tag next
-          commit: "ci(changesets): versioning packages"
-          title: "ci(changesets): versioning packages"
           createGithubReleases: aggregate
-          githubReleaseName: v${{ env.BUILD_VERSION }}
-          githubTagName: v${{ env.BUILD_VERSION }}
+          version: pnpm changeset version
         env:
           GITHUB_TOKEN: ${{ secrets.REPO_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN_WALLET: ${{ secrets.NPM_TOKEN_WALLET }}
 
       - name: Build Fuel Wallet
         if: steps.changesets.outputs.published == 'true'
         run: pnpm build:crx
         env:
-          ## increase node.js m memory limit for building
-          ## with sourcemaps
           NODE_OPTIONS: "--max-old-space-size=4096"
 
       - name: Build Fuel Wallet Development


### PR DESCRIPTION
- Closes FE-1451


# Summary

- Split release workflow into multiple jobs for better separation of concerns
- Add job to check if the current commit is from a changeset PR
- Create separate jobs for creating changeset PRs and publishing to npm
- Improve workflow logic to handle different release scenarios


# Checklist

- [x] I've added error handling for all actions/requests, and verified how this error will show on UI. (or there was no error handling)
- [x] I've reviewed all the copy changed/added in this PR, using AI if needed. (or there was no copy changes)
- [x] I've included the reference to the issues being closed from Github and/or Linear (or there was no issues)
- [x] I've changed the Docs to reflect my changes (or it was not needed)
- [x] I've put docs links where it may be helpful (or it was not needed)
- [x] I checked the resulting UI both in Light and Dark mode (or no UI changes were made)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
