### PR TITLE
fix: release action conditional

### DIFF
--- a/.github/workflows/release-npm-changeset.yaml
+++ b/.github/workflows/release-npm-changeset.yaml
@@ -26,11 +26,14 @@ jobs:
         with:
           fetch-depth: 0
       - id: check-commit
+        name: Check if this commit is a regular merge or a changeset PR merge
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if [[ "${{ github.event.head_commit.message }}" == "Merge pull request"* ]]; then
-            PR_NUMBER=$(echo "${{ github.event.head_commit.message }}" | grep -o '#[0-9]\+' | tr -d '#')
+          COMMIT_MSG=$(git log -1 --pretty=%B)
+          FIRST_LINE=$(echo "$COMMIT_MSG" | head -n1)
+          if [[ "$FIRST_LINE" == "ci(changesets): versioning packages"* ]]; then
+            PR_NUMBER=$(echo "$FIRST_LINE" | grep -o '#[0-9]\+' | head -n1 | tr -d '#')
             if [ -n "$PR_NUMBER" ]; then
               PR_TITLE=$(gh pr view "$PR_NUMBER" --json title -q .title)
               if [[ "$PR_TITLE" == "ci(changesets): versioning packages" ]]; then


### PR DESCRIPTION
- Closes FE-1452

# Summary
Fix conditionals that were deciding if release on NPM or push to the changeset PR

# Checklist

- [x] I've added error handling for all actions/requests, and verified how this error will show on UI. (or there was no error handling)
- [x] I've reviewed all the copy changed/added in this PR, using AI if needed. (or there was no copy changes)
- [x] I've included the reference to the issues being closed from Github and/or Linear (or there was no issues)
- [x] I've changed the Docs to reflect my changes (or it was not needed)
- [x] I've put docs links where it may be helpful (or it was not needed)
- [x] I checked the resulting UI both in Light and Dark mode (or no UI changes were made)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
