### PR TITLE
fix: playwright export pointing to wrong file extension

### DIFF
--- a/.changeset/purple-feet-rush.md
+++ b/.changeset/purple-feet-rush.md
@@ -1,0 +1,5 @@
+---
+"@fuels/playwright-utils": patch
+---
+
+fix: playwright export pointing to wrong file extension

--- a/packages/playwright-utils/package.json
+++ b/packages/playwright-utils/package.json
@@ -7,13 +7,13 @@
   "publishConfig": {
     "access": "public",
     "main": "./dist/index.js",
-    "module": "./dist/index.mjs",
+    "module": "./dist/index.js",
     "types": "./dist/index.d.ts",
     "typings": "./dist/index.d.ts",
     "exports": {
       ".": {
         "require": "./dist/index.js",
-        "default": "./dist/index.mjs"
+        "default": "./dist/index.js"
       }
     }
   },


### PR DESCRIPTION

tsup + type "module" will generate js and not mjs for esm exports



- [x] I've added error handling for all actions/requests, and verified how this error will show on UI. (or there was no error handling)
- [x] I've reviewed all the copy changed/added in this PR, using AI if needed. (or there was no copy changes)
- [x] I've included the reference to the issues being closed from Github and/or Linear (or there was no issues)
- [x] I've changed the Docs to reflect my changes (or it was not needed)
- [x] I've put docs links where it may be helpful (or it was not needed)
- [x] I checked the resulting UI both in Light and Dark mode (or no UI changes were made)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
