### PR TITLE
feat: lowercase 'To' address before comparing with assetId in TransferAssets.tsx

### DIFF
--- a/packages/docs/examples/assets/TransferAssets.tsx
+++ b/packages/docs/examples/assets/TransferAssets.tsx
@@ -54,7 +54,7 @@ export function TransferAssets() {
       // Create a Wallet instance from the current account
       const wallet = await fuel.getWallet(account);
       // Create a Address instance to the receiver address
-      const toAddress = Address.fromString(receiverAddress);
+      const toAddress = Address.fromString(receiverAddress.toLowerCase());
       // Send a transaction to transfer the asset to the receiver address
       const response = await wallet.transfer(toAddress, amount, assetId, {
         gasLimit: 5_000,


### PR DESCRIPTION

---

### **Lowercase "To" Address Before Comparing with `assetId` in `TransferAssets.tsx`**  

#### **Closes**  
- #1828

#### **Summary**  
This PR ensures that the "To" address is consistently lowercased before comparison with `assetId` in `TransferAssets.tsx`. This prevents potential case-sensitivity issues that could cause incorrect asset transfers or mismatches.  

#### **Changes**  
- Converted the "To" address to lowercase before performing a comparison with `assetId`.  
- Ensured that address handling remains consistent throughout the transfer logic.  


