### PR TITLE
Nj/feat/nft images in dropdown

### DIFF
--- a/packages/app/src/systems/Account/components/BalanceNFTs/NFTImage.tsx
+++ b/packages/app/src/systems/Account/components/BalanceNFTs/NFTImage.tsx
@@ -1,5 +1,5 @@
 import { cssObj } from '@fuel-ui/css';
-import { Box, ContentLoader, Icon, Image } from '@fuel-ui/react';
+import { Box, Icon, Image } from '@fuel-ui/react';
 import { memo, useEffect, useRef, useState } from 'react';
 import { NFTImageLoading } from '~/systems/Account/components/BalanceNFTs/NFTImageLoading';
 import { shortAddress } from '~/systems/Core';

--- a/packages/app/src/systems/Asset/components/AssetSelect/AssetSelect.tsx
+++ b/packages/app/src/systems/Asset/components/AssetSelect/AssetSelect.tsx
@@ -11,6 +11,7 @@ import {
 } from '@fuel-ui/react';
 import type { AssetFuelAmount } from '@fuel-wallet/types';
 import { memo, useState } from 'react';
+import { NFTImage } from '~/systems/Account/components/BalanceNFTs/NFTImage';
 import type { Maybe } from '~/systems/Core';
 import { coreStyles, shortAddress } from '~/systems/Core';
 
@@ -28,6 +29,11 @@ function AssetSelectBase({ items, selected, onSelect }: AssetSelectProps) {
 
   function handleClear() {
     onSelect(null);
+  }
+
+  function getImageUrl(asset?: AssetSelectInput) {
+    if (!asset?.metadata?.image) return asset?.icon;
+    return asset.metadata.image.replace('ipfs://', 'https://ipfs.io/ipfs/');
   }
 
   return (
@@ -55,30 +61,33 @@ function AssetSelectBase({ items, selected, onSelect }: AssetSelectProps) {
           }
         >
           <Box.Flex css={styles.input}>
-            {assetAmount &&
-              (assetAmount.name ? (
-                <>
+            {assetAmount && (
+              <>
+                {assetAmount.isNft ? (
+                  <Box css={styles.nftPreview}>
+                    <NFTImage
+                      assetId={assetAmount.assetId || ''}
+                      image={getImageUrl(assetAmount)}
+                    />
+                  </Box>
+                ) : assetAmount.name ? (
                   <Avatar
                     name={assetAmount?.name}
                     src={assetAmount?.icon}
                     css={{ height: 18, width: 18 }}
                   />
-                  <Text as="span" className="asset-name">
-                    {assetAmount?.name}
-                  </Text>
-                </>
-              ) : (
-                <>
+                ) : (
                   <Avatar.Generated
                     hash={assetAmount.assetId || ''}
                     css={{ height: 14, width: 14 }}
                     size="xsm"
                   />
-                  <Text as="span" className="asset-name">
-                    {shortAddress(assetAmount?.assetId)}
-                  </Text>
-                </>
-              ))}
+                )}
+                <Text as="span" className="asset-name">
+                  {assetAmount.name || shortAddress(assetAmount?.assetId)}
+                </Text>
+              </>
+            )}
             {!assetAmount && (
               <Text as="span" css={styles.placeholder}>
                 Select one asset
@@ -112,7 +121,14 @@ function AssetSelectBase({ items, selected, onSelect }: AssetSelectProps) {
               key={item.assetId?.toString()}
               textValue={item.assetId?.toString()}
             >
-              {icon ? (
+              {isNft ? (
+                <Box css={styles.nftPreview}>
+                  <NFTImage
+                    assetId={assetId || ''}
+                    image={getImageUrl(itemAsset)}
+                  />
+                </Box>
+              ) : icon ? (
                 <Avatar size="xsm" name={name || ''} src={icon} />
               ) : (
                 <Avatar.Generated size="sm" hash={assetId || ''} />
@@ -241,5 +257,14 @@ const styles = {
     ml: '$2',
     fontSize: '$sm',
     lineHeight: 'normal',
+  }),
+  nftPreview: cssObj({
+    '&': {
+      width: '30px',
+      height: '30px',
+    },
+    '.fuel_Box': {
+      minHeight: 'unset !important',
+    },
   }),
 };

--- a/packages/app/src/systems/Asset/components/AssetSelect/AssetSelect.tsx
+++ b/packages/app/src/systems/Asset/components/AssetSelect/AssetSelect.tsx
@@ -32,8 +32,34 @@ function AssetSelectBase({ items, selected, onSelect }: AssetSelectProps) {
   }
 
   function getImageUrl(asset?: AssetSelectInput) {
-    if (!asset?.metadata?.image) return asset?.icon;
-    return asset.metadata.image.replace('ipfs://', 'https://ipfs.io/ipfs/');
+    try {
+      if (!asset?.metadata?.image) return asset?.icon;
+      const imageUrl = asset.metadata.image;
+      return typeof imageUrl === 'string'
+        ? imageUrl.replace('ipfs://', 'https://ipfs.io/ipfs/')
+        : asset?.icon;
+    } catch (error) {
+      console.warn('Error getting NFT image URL:', error);
+      return asset?.icon;
+    }
+  }
+
+  function getName(asset?: AssetSelectInput) {
+    try {
+      if (!asset) return 'Unknown';
+
+      if (asset.isNft && asset.metadata?.name) {
+        const name = asset.metadata.name;
+        return typeof name === 'string' && name.trim()
+          ? name.trim()
+          : shortAddress(asset.assetId);
+      }
+
+      return asset.name?.trim() || shortAddress(asset.assetId);
+    } catch (error) {
+      console.warn('Error getting asset name:', error);
+      return shortAddress(asset?.assetId);
+    }
   }
 
   return (
@@ -84,7 +110,7 @@ function AssetSelectBase({ items, selected, onSelect }: AssetSelectProps) {
                   />
                 )}
                 <Text as="span" className="asset-name">
-                  {assetAmount.name || shortAddress(assetAmount?.assetId)}
+                  {getName(assetAmount)}
                 </Text>
               </>
             )}
@@ -114,7 +140,7 @@ function AssetSelectBase({ items, selected, onSelect }: AssetSelectProps) {
         {(items || []).map((item) => {
           const assetId = item.assetId?.toString();
           const itemAsset = items?.find((a) => a.assetId === assetId);
-          const { name, symbol, icon, isNft } = itemAsset || {};
+          const { symbol, icon, isNft } = itemAsset || {};
 
           return (
             <Dropdown.MenuItem
@@ -129,13 +155,13 @@ function AssetSelectBase({ items, selected, onSelect }: AssetSelectProps) {
                   />
                 </Box>
               ) : icon ? (
-                <Avatar size="xsm" name={name || ''} src={icon} />
+                <Avatar size="xsm" name={getName(itemAsset)} src={icon} />
               ) : (
                 <Avatar.Generated size="sm" hash={assetId || ''} />
               )}
               <Box className="asset-info">
                 <Text as="span" className="asset-name">
-                  {name || 'Unknown'}
+                  {getName(itemAsset)}
                   {isNft && (
                     <Badge
                       variant="ghost"


### PR DESCRIPTION
- Closes FE-1523

# Summary
Show NFT images in Asset List
![image](https://github.com/user-attachments/assets/cf9cbcf3-a6f8-4667-a928-0b66e4219e5b)

# Checklist

- [x] I've added error handling for all actions/requests, and verified how this error will show on UI. (or there was no error handling)
- [x] I've reviewed all the copy changed/added in this PR, using AI if needed. (or there was no copy changes)
- [x] I've included the reference to the issues being closed from Github and/or Linear (or there was no issues)
- [x] I've changed the Docs to reflect my changes (or it was not needed)
- [x] I've put docs links where it may be helpful (or it was not needed)
- [x] I checked the resulting UI both in Light and Dark mode (or no UI changes were made)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
