### PR TITLE
feat: show Withdraw operation when it has MESSAGE_OUT receipt + improve order of assets in Send Page

### DIFF
--- a/.changeset/warm-otters-sleep.md
+++ b/.changeset/warm-otters-sleep.md
@@ -1,0 +1,5 @@
+---
+"fuels-wallet": patch
+---
+
+feat: show Withdraw operation when it has MESSAGE_OUT receipt + improve order of assets in Send Page

--- a/packages/app/src/systems/Account/components/EthAddress/EthAddress.tsx
+++ b/packages/app/src/systems/Account/components/EthAddress/EthAddress.tsx
@@ -14,10 +14,35 @@ export const EthAddress = ({ address, css }: EthAddressProps) => {
   const ethAddress = isValidAddress ? bn(address).toHex(20) : '';
 
   return (
-    <Box.Flex>
-      <Copyable value={ethAddress} aria-label={address}>
-        <Text css={css}>{shortAddress(ethAddress)}</Text>
+    <Box.Flex align="center" gap="$0" css={styles.root}>
+      <Copyable value={ethAddress} css={styles.copyable} aria-label={address}>
+        <Text className="address" css={css}>
+          {shortAddress(ethAddress)}
+        </Text>
       </Copyable>
     </Box.Flex>
   );
+};
+
+const styles = {
+  root: cssObj({
+    '.address_tooltip': cssObj({
+      fontSize: '$sm',
+      lineHeight: '$4',
+      maxWidth: 125,
+      textAlign: 'center',
+      wordWrap: 'break-word',
+    }),
+    '.address': {
+      userSelect: 'none',
+    },
+  }),
+  copyable: cssObj({
+    // to make sure we're using same text format, we just hide the copy icon but still use Copyable.
+    '&[data-invalid-address="true"]': {
+      '.fuel_copyable-icon': {
+        display: 'none',
+      },
+    },
+  }),
 };

--- a/packages/app/src/systems/Asset/components/AssetSelect/AssetSelect.tsx
+++ b/packages/app/src/systems/Asset/components/AssetSelect/AssetSelect.tsx
@@ -163,11 +163,7 @@ function AssetSelectBase({ items, selected, onSelect }: AssetSelectProps) {
                 <Text as="span" className="asset-name">
                   {getName(itemAsset)}
                   {isNft && (
-                    <Badge
-                      variant="ghost"
-                      intent="primary"
-                      css={styles.assetNft}
-                    >
+                    <Badge variant="outlined" css={styles.assetNft}>
                       NFT
                     </Badge>
                   )}

--- a/packages/app/src/systems/Send/components/SendSelect/SendSelect.tsx
+++ b/packages/app/src/systems/Send/components/SendSelect/SendSelect.tsx
@@ -105,10 +105,19 @@ export function SendSelect({
     handlers.recalculateFromAmount,
   ]);
 
-  const assetSelectItems = balances?.map((b) => ({
-    assetId: b.assetId,
-    ...b.asset,
-  }));
+  const assetSelectItems = balances
+    ?.map((b) => ({
+      assetId: b.assetId,
+      ...b.asset,
+    }))
+    .sort((a, b) => {
+      if (a.verified !== b.verified) return b.verified ? 1 : -1;
+      if (a.isNft !== b.isNft) return b.isNft ? 1 : -1;
+      if (a.collection !== b.collection)
+        return (a.collection || '').localeCompare(b.collection || '');
+      if (a.name !== b.name) return (a.name || '').localeCompare(b.name || '');
+      return (a.assetId || '').localeCompare(b.assetId || '');
+    });
 
   return (
     <MotionContent {...animations.slideInTop()}>

--- a/packages/app/src/systems/Transaction/pages/TxApprove/TxApprove.tsx
+++ b/packages/app/src/systems/Transaction/pages/TxApprove/TxApprove.tsx
@@ -111,7 +111,7 @@ const styles = {
   description: cssObj({
     ...coreStyles.scrollable('$intentsBase3'),
     overflowY: 'auto !important',
-    padding: '0 $2 0 $2',
+    padding: '0 $2 0 $3',
     flex: 1,
     display: 'flex',
     flexDirection: 'column',

--- a/packages/app/src/systems/Transaction/services/transaction.tsx
+++ b/packages/app/src/systems/Transaction/services/transaction.tsx
@@ -217,8 +217,6 @@ export class TxService {
     transactionState,
     transactionSummary,
   }: TxInputs['simulateTransaction']) {
-    // await delay(4000);
-    // debugger;
     const provider = new Provider(providerConfig?.url || '', {
       cache: providerConfig?.cache,
     });

--- a/packages/app/src/systems/Transaction/services/transformers/simplifyTransaction.ts
+++ b/packages/app/src/systems/Transaction/services/transformers/simplifyTransaction.ts
@@ -380,16 +380,25 @@ export function getMainOperations(
 
   return mainOperations;
 }
-export const getOperationText = (
-  isContract: boolean,
-  isTransfer: boolean,
-  assetsAmount?: AssetFuelAmount[]
-) => {
+export const getOperationText = ({
+  isContract,
+  isTransfer,
+  assetsAmount,
+  hasMessageOut,
+}: {
+  isContract: boolean;
+  isTransfer: boolean;
+  assetsAmount?: AssetFuelAmount[];
+  hasMessageOut?: boolean;
+}) => {
   if (isContract) {
     if (assetsAmount && assetsAmount.length > 0) {
       return 'Calls contract (sending funds)';
     }
     return 'Calls contract';
+  }
+  if (hasMessageOut) {
+    return 'Withdraws to Ethereum network';
   }
   if (isTransfer) {
     return 'Sends funds';


### PR DESCRIPTION

- Closes #1877
- Closes #1876
- Closes FE-1554
- Closes FE-1553


# Summary
- Improve sorting of Send Page assets (verified first, then nfts, then unknown assets, etc..)
- Show "Withdraw" operation when it has MESSAGE_OUT receipt


# Checklist

- [x] I've added error handling for all actions/requests, and verified how this error will show on UI. (or there was no error handling)
- [x] I've reviewed all the copy changed/added in this PR, using AI if needed. (or there was no copy changes)
- [x] I've included the reference to the issues being closed from Github and/or Linear (or there was no issues)
- [x] I've changed the Docs to reflect my changes (or it was not needed)
- [x] I've put docs links where it may be helpful (or it was not needed)
- [x] I checked the resulting UI both in Light and Dark mode (or no UI changes were made)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
