### PR TITLE
feat: Add balance to Send Screen -> Asset select

### DIFF
--- a/packages/app/src/systems/Asset/components/AssetSelect/AssetSelect.tsx
+++ b/packages/app/src/systems/Asset/components/AssetSelect/AssetSelect.tsx
@@ -10,12 +10,15 @@ import {
   Text,
 } from '@fuel-ui/react';
 import type { AssetFuelAmount } from '@fuel-wallet/types';
+import type { BN } from 'fuels';
 import { memo, useState } from 'react';
 import { NFTImage } from '~/systems/Account/components/BalanceNFTs/NFTImage';
 import type { Maybe } from '~/systems/Core';
 import { coreStyles, shortAddress } from '~/systems/Core';
 
-export type AssetSelectInput = Partial<AssetFuelAmount>;
+export type AssetSelectInput = Partial<AssetFuelAmount> & {
+  formattedBalance?: string;
+};
 
 export type AssetSelectProps = {
   items?: Maybe<AssetSelectInput[]>;
@@ -172,6 +175,13 @@ function AssetSelectBase({ items, selected, onSelect }: AssetSelectProps) {
                   {symbol || shortAddress(assetId)}
                 </Text>
               </Box>
+              <Box>
+                {itemAsset?.formattedBalance && (
+                  <Text as="span" className="asset-balance">
+                    {itemAsset.formattedBalance}
+                  </Text>
+                )}
+              </Box>
             </Dropdown.MenuItem>
           );
         })}
@@ -262,14 +272,18 @@ const styles = {
     '.asset-info': {
       flex: 1,
       mr: '$3',
-    },
-    '.asset-name, .asset-symbol': {
-      display: 'block',
-      fontSize: '$sm',
-      lineHeight: '$tight',
-    },
-    '.asset-name': {
-      mb: '2px',
+      '.asset-name': {
+        display: 'flex',
+        alignItems: 'center',
+        color: '$intentsBase12',
+        fontSize: '$sm',
+        fontWeight: '$normal',
+        lineHeight: 'normal',
+      },
+      '.asset-symbol, .asset-balance': {
+        color: '$intentsBase10',
+        fontSize: '$xs',
+      },
     },
   }),
   dropdownRoot: cssObj({


### PR DESCRIPTION
- Closes FE-1555

# Summary
Add balance in the Send Page -> Asset Select (in the same fashion we have in the Fuel Bridge) with USD values.
<img width="353" alt="image" src="https://github.com/user-attachments/assets/5c56ed1b-da8d-449a-8e50-e9479ef4c9e2" />


# Checklist

- [x] I've added error handling for all actions/requests, and verified how this error will show on UI. (or there was no error handling)
- [x] I've reviewed all the copy changed/added in this PR, using AI if needed. (or there was no copy changes)
- [x] I've included the reference to the issues being closed from Github and/or Linear (or there was no issues)
- [x] I've changed the Docs to reflect my changes (or it was not needed)
- [x] I've put docs links where it may be helpful (or it was not needed)
- [x] I checked the resulting UI both in Light and Dark mode (or no UI changes were made)
- [ ] I **reviewed** the **entire PR** myself (preferably, on GH UI)
