### PR TITLE
fix: change form validation mode to 'all' and add error delay in useS…

### DIFF
--- a/packages/app/src/systems/Send/hooks/useSend.tsx
+++ b/packages/app/src/systems/Send/hooks/useSend.tsx
@@ -338,7 +338,7 @@ export function useSend() {
   );
   const form = useForm<SendFormValues>({
     resolver,
-    mode: 'onSubmit',
+    mode: 'all',
     defaultValues: DEFAULT_VALUES,
     context: {
       balances: account?.balances,
@@ -346,6 +346,7 @@ export function useSend() {
       gasLimit,
       maxGasLimit,
     },
+    delayError: 1000,
   });
 
   const tip = useWatch({


### PR DESCRIPTION
- Closes FE-1574

# Summary

An error would blink in the amount validation when switching from an invalid to a vladi amount, as for example`0.` would be considered invalid, as a transient value, but due to the validation delay, it was not a good UX.
This PR finds a simple solution to improve this.

### Old behavior:
<video src="https://github.com/user-attachments/assets/4b7e2174-b909-4516-a57e-067b0e2c9319" controls></video>

### Now:
<video src="https://github.com/user-attachments/assets/c3de8e82-64e5-4b12-bbe3-9fc9fe902d00" controls></video>

# Checklist

- [ ] I've added error handling for all actions/requests, and verified how this error will show on UI. (or there was no error handling)
- [ ] I've reviewed all the copy changed/added in this PR, using AI if needed. (or there was no copy changes)
- [ ] I've included the reference to the issues being closed from Github and/or Linear (or there was no issues)
- [ ] I've changed the Docs to reflect my changes (or it was not needed)
- [ ] I've put docs links where it may be helpful (or it was not needed)
- [ ] I checked the resulting UI both in Light and Dark mode (or no UI changes were made)
- [ ] I **reviewed** the **entire PR** myself (preferably, on GH UI)
