### PR TITLE
Nj/fix/large asset amounts

### DIFF
--- a/.changeset/slimy-chefs-dress.md
+++ b/.changeset/slimy-chefs-dress.md
@@ -1,0 +1,5 @@
+---
+"fuels-wallet": minor
+---
+
+Improve the visualization of very large amounts in the transaction operations view.

--- a/packages/app/src/systems/Transaction/components/TxOperation/TxOperationAssets.tsx
+++ b/packages/app/src/systems/Transaction/components/TxOperation/TxOperationAssets.tsx
@@ -162,7 +162,7 @@ export function TxOperationAssets({ amounts }: TxOperationAssetsProps) {
             {getAssetImage(assetAmount as AssetFuelAmount)}
             <Box css={styles.amountContainer}>
               <Box.Flex direction="column">
-                <Box.Flex gap="$2" align="center">
+                <Box.Flex gap="$2" align="center" wrap="wrap">
                   <Text
                     as="span"
                     color="textHeading"


### PR DESCRIPTION
- Closes FE-1607

# Summary
![image](https://github.com/user-attachments/assets/37aad42e-6e87-4a32-a84c-26d362f3db9e)
![image](https://github.com/user-attachments/assets/a247a7fb-0c26-4d4d-9961-f332fa6a7f37)

# Checklist

- [x] I've added error handling for all actions/requests, and verified how this error will show on UI. (or there was no error handling)
- [x] I've reviewed all the copy changed/added in this PR, using AI if needed. (or there was no copy changes)
- [x] I've included the reference to the issues being closed from Github and/or Linear (or there was no issues)
- [x] I've changed the Docs to reflect my changes (or it was not needed)
- [x] I've put docs links where it may be helpful (or it was not needed)
- [x] I checked the resulting UI both in Light and Dark mode (or no UI changes were made)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
