### PR TITLE
fix: include dryRun before showing transaction on approval screen coming from dapp

### DIFF
--- a/.changeset/dirty-planes-tie.md
+++ b/.changeset/dirty-planes-tie.md
@@ -1,0 +1,5 @@
+---
+"fuels-wallet": patch
+---
+
+Fix transaction validation logic.

--- a/.changeset/dirty-planes-tie.md
+++ b/.changeset/dirty-planes-tie.md
@@ -2,4 +2,4 @@
 "fuels-wallet": patch
 ---
 
-Fix transaction validation logic.
+Remove flawed transaction validation logic.

--- a/.changeset/dirty-planes-tie.md
+++ b/.changeset/dirty-planes-tie.md
@@ -2,4 +2,4 @@
 "fuels-wallet": patch
 ---
 
-Remove flawed transaction validation logic.
+fix: include dryRun before showing transaction on approval screen coming from dapp

--- a/packages/app/src/systems/DApp/machines/transactionRequestMachine.tsx
+++ b/packages/app/src/systems/DApp/machines/transactionRequestMachine.tsx
@@ -248,7 +248,6 @@ export const transactionRequestMachine = createMachine(
             input: (ctx: MachineContext) => ({
               ...ctx.input,
               transactionRequest: ctx.response?.proposedTxRequest,
-              displayedSummary: ctx.response?.txSummarySimulated,
             }),
           },
           onDone: [

--- a/packages/app/src/systems/DApp/machines/transactionRequestMachine.tsx
+++ b/packages/app/src/systems/DApp/machines/transactionRequestMachine.tsx
@@ -248,6 +248,7 @@ export const transactionRequestMachine = createMachine(
             input: (ctx: MachineContext) => ({
               ...ctx.input,
               transactionRequest: ctx.response?.proposedTxRequest,
+              displayedSummary: ctx.response?.txSummarySimulated,
             }),
           },
           onDone: [

--- a/packages/app/src/systems/Transaction/services/transaction.tsx
+++ b/packages/app/src/systems/Transaction/services/transaction.tsx
@@ -253,17 +253,21 @@ export class TxService {
       abiMap,
     });
 
-    if (displayedSummary) {
-      const isDisplayValid = compareTransactionSummaries({
-        summary1: displayedSummary,
-        summary2: afterDryRunSummary,
-      });
+    if (!displayedSummary) {
+      throw new Error(
+        'Internal validation error: Displayed transaction summary is missing.'
+      );
+    }
 
-      if (!isDisplayValid) {
-        throw new Error(
-          'Transaction execution was blocked: The displayed transaction details may differ from the actual execution.'
-        );
-      }
+    const isDisplayValid = compareTransactionSummaries({
+      summary1: displayedSummary,
+      summary2: afterDryRunSummary,
+    });
+
+    if (!isDisplayValid) {
+      throw new Error(
+        'Transaction execution was blocked: The displayed transaction details may differ from the actual execution.'
+      );
     }
 
     const txSent = await wallet.sendTransaction(transactionRequest);


### PR DESCRIPTION
- Closes FE-Z

# Summary
The summary validation logic had a logic flaw.

# Checklist

- [ ] I've added error handling for all actions/requests, and verified how this error will show on UI. (or there was no error handling)
- [x] I've reviewed all the copy changed/added in this PR, using AI if needed. (or there was no copy changes)
- [x] I've included the reference to the issues being closed from Github and/or Linear (or there was no issues)
- [x] I've changed the Docs to reflect my changes (or it was not needed)
- [x] I've put docs links where it may be helpful (or it was not needed)
- [x] I checked the resulting UI both in Light and Dark mode (or no UI changes were made)
- [ ] I **reviewed** the **entire PR** myself (preferably, on GH UI)
