### PR TITLE
feat: Implement signTransaction method for no-broadcast signing

### DIFF
--- a/.changeset/twenty-peas-reply.md
+++ b/.changeset/twenty-peas-reply.md
@@ -1,0 +1,5 @@
+---
+"fuels-wallet": minor
+---
+
+feat: The Fuel Wallet now support signing transactions without directly broadcasting to the network.

--- a/.changeset/twenty-peas-reply.md
+++ b/.changeset/twenty-peas-reply.md
@@ -2,4 +2,4 @@
 "fuels-wallet": minor
 ---
 
-feat: The Fuel Wallet now support signing transactions without directly broadcasting to the network.
+feat: add support for dapps to sign transactions using Fuel Wallet, without sending them to the network.

--- a/packages/app/src/systems/CRX/background/services/BackgroundService.ts
+++ b/packages/app/src/systems/CRX/background/services/BackgroundService.ts
@@ -376,7 +376,7 @@ export class BackgroundService {
       title,
       favIconUrl,
       skipCustomFee: true,
-      noSendReturnPayload: true, // Flag to just sign, not broadcast
+      signOnly: true, // Flag to just sign, not broadcast
     });
 
     popupService.destroy();

--- a/packages/app/src/systems/CRX/background/services/BackgroundService.ts
+++ b/packages/app/src/systems/CRX/background/services/BackgroundService.ts
@@ -302,7 +302,6 @@ export class BackgroundService {
     const favIconUrl = serverParams.favIconUrl;
     const selectedNetwork = await NetworkService.getSelectedNetwork();
 
-    console.log('sendTransaction', input);
     if (selectedNetwork?.url !== input.provider.url) {
       throw new Error(
         [
@@ -349,26 +348,15 @@ export class BackgroundService {
     input: Exclude<MessageInputs['signTransaction'], 'origin'>,
     serverParams: EventOrigin
   ) {
-    console.log('[BackgroundService] signTransaction called with input:', {
-      address: input.address,
-      hasProvider: !!input.provider,
-      providerUrl: input.provider?.url,
-    });
-
     await this.requireAccountConnection(serverParams.connection, input.address);
     const origin = serverParams.origin;
     const title = serverParams.title;
     const favIconUrl = serverParams.favIconUrl;
     const selectedNetwork = await NetworkService.getSelectedNetwork();
 
-    // Make sure we have a valid provider URL
     if (!input.provider || !input.provider.url) {
-      console.log(
-        '[BackgroundService] Adding missing provider URL:',
-        selectedNetwork?.url
-      );
       input.provider = {
-        url: selectedNetwork?.url || '', // Add fallback empty string
+        url: selectedNetwork?.url || '',
       };
     }
 
@@ -380,9 +368,6 @@ export class BackgroundService {
 
     const address = Address.fromDynamicInput(input.address).toString();
 
-    console.log(
-      '[BackgroundService] Calling popupService.sendTransaction with noSendReturnPayload=true'
-    );
     const result = await popupService.sendTransaction({
       address,
       provider: input.provider,
@@ -393,8 +378,6 @@ export class BackgroundService {
       skipCustomFee: true,
       noSendReturnPayload: true, // Flag to just sign, not broadcast
     });
-
-    console.log('[BackgroundService] signTransaction result:', result);
 
     popupService.destroy();
     return result;

--- a/packages/app/src/systems/CRX/background/services/BackgroundService.ts
+++ b/packages/app/src/systems/CRX/background/services/BackgroundService.ts
@@ -368,19 +368,17 @@ export class BackgroundService {
 
     const address = Address.fromDynamicInput(input.address).toString();
 
-    const result = await popupService.sendTransaction({
+    const txRequestSigned = await popupService.signTransaction({
       address,
       provider: input.provider,
       transaction: input.transaction,
       origin,
       title,
       favIconUrl,
-      skipCustomFee: true,
-      signOnly: true, // Flag to just sign, not broadcast
     });
 
     popupService.destroy();
-    return result;
+    return txRequestSigned;
   }
 
   async currentAccount(_: unknown, serverParams: EventOrigin) {

--- a/packages/app/src/systems/CRX/background/services/PopUpService.ts
+++ b/packages/app/src/systems/CRX/background/services/PopUpService.ts
@@ -206,15 +206,6 @@ export class PopUpService {
     return this.client.request('sendTransaction', input);
   }
 
-  async signTransaction(input: MessageInputs['signTransaction']) {
-    const result = await this.client.request('sendTransaction', {
-      ...input,
-      noSendReturnPayload: true,
-    });
-
-    return result;
-  }
-
   async addAssets(input: MessageInputs['addAssets']) {
     return this.client.request('addAssets', input);
   }

--- a/packages/app/src/systems/CRX/background/services/PopUpService.ts
+++ b/packages/app/src/systems/CRX/background/services/PopUpService.ts
@@ -206,6 +206,10 @@ export class PopUpService {
     return this.client.request('sendTransaction', input);
   }
 
+  async signTransaction(input: MessageInputs['signTransaction']) {
+    return this.client.request('signTransaction', input);
+  }
+
   async addAssets(input: MessageInputs['addAssets']) {
     return this.client.request('addAssets', input);
   }

--- a/packages/app/src/systems/CRX/background/services/PopUpService.ts
+++ b/packages/app/src/systems/CRX/background/services/PopUpService.ts
@@ -203,29 +203,15 @@ export class PopUpService {
   }
 
   async sendTransaction(input: MessageInputs['sendTransaction']) {
-    console.log('[PopUpService] sendTransaction called with input:', {
-      address: input.address,
-      hasProvider: !!input.provider,
-      providerUrl: input.provider?.url,
-      noSendReturnPayload: input.noSendReturnPayload,
-    });
     return this.client.request('sendTransaction', input);
   }
 
   async signTransaction(input: MessageInputs['signTransaction']) {
-    console.log('[PopUpService] signTransaction called with input:', {
-      address: input.address,
-      hasProvider: !!input.provider,
-      providerUrl: input.provider?.url,
-    });
-
-    // Use sendTransaction with noSendReturnPayload flag
     const result = await this.client.request('sendTransaction', {
       ...input,
       noSendReturnPayload: true,
     });
 
-    console.log('[PopUpService] signTransaction result:', result);
     return result;
   }
 

--- a/packages/app/src/systems/CRX/background/services/PopUpService.ts
+++ b/packages/app/src/systems/CRX/background/services/PopUpService.ts
@@ -203,7 +203,30 @@ export class PopUpService {
   }
 
   async sendTransaction(input: MessageInputs['sendTransaction']) {
+    console.log('[PopUpService] sendTransaction called with input:', {
+      address: input.address,
+      hasProvider: !!input.provider,
+      providerUrl: input.provider?.url,
+      noSendReturnPayload: input.noSendReturnPayload,
+    });
     return this.client.request('sendTransaction', input);
+  }
+
+  async signTransaction(input: MessageInputs['signTransaction']) {
+    console.log('[PopUpService] signTransaction called with input:', {
+      address: input.address,
+      hasProvider: !!input.provider,
+      providerUrl: input.provider?.url,
+    });
+
+    // Use sendTransaction with noSendReturnPayload flag
+    const result = await this.client.request('sendTransaction', {
+      ...input,
+      noSendReturnPayload: true,
+    });
+
+    console.log('[PopUpService] signTransaction result:', result);
+    return result;
   }
 
   async addAssets(input: MessageInputs['addAssets']) {

--- a/packages/app/src/systems/CRX/background/services/types.ts
+++ b/packages/app/src/systems/CRX/background/services/types.ts
@@ -14,6 +14,14 @@ export type MessageInputs = {
     title?: string;
     favIconUrl?: string;
   };
+  signTransaction: {
+    address: string;
+    origin: string;
+    title?: string;
+    favIconUrl?: string;
+    provider: FuelProviderConfig;
+    transaction: string;
+  };
   sendTransaction: {
     address: string;
     origin: string;
@@ -25,6 +33,7 @@ export type MessageInputs = {
     transactionState?: 'funded' | undefined;
     transactionSummary?: TransactionSummaryJson;
     returnTransactionResponse?: boolean;
+    noSendReturnPayload?: boolean;
   };
   addAssets: {
     assets: AssetData[];

--- a/packages/app/src/systems/CRX/background/services/types.ts
+++ b/packages/app/src/systems/CRX/background/services/types.ts
@@ -33,7 +33,7 @@ export type MessageInputs = {
     transactionState?: 'funded' | undefined;
     transactionSummary?: TransactionSummaryJson;
     returnTransactionResponse?: boolean;
-    noSendReturnPayload?: boolean;
+    signOnly?: boolean;
   };
   addAssets: {
     assets: AssetData[];

--- a/packages/app/src/systems/Core/utils/wallet.ts
+++ b/packages/app/src/systems/Core/utils/wallet.ts
@@ -41,7 +41,6 @@ export class WalletLockedCustom extends WalletLocked {
   async sendTransaction(
     transactionRequestLike: TransactionRequestLike
   ): Promise<TransactionResponse> {
-    console.log('sendTransaction', transactionRequestLike);
     const transactionRequest = transactionRequestify(transactionRequestLike);
     const txRequestToSend =
       await this.populateTransactionWitnessesSignature(transactionRequest);

--- a/packages/app/src/systems/Core/utils/wallet.ts
+++ b/packages/app/src/systems/Core/utils/wallet.ts
@@ -41,6 +41,7 @@ export class WalletLockedCustom extends WalletLocked {
   async sendTransaction(
     transactionRequestLike: TransactionRequestLike
   ): Promise<TransactionResponse> {
+    console.log('sendTransaction', transactionRequestLike);
     const transactionRequest = transactionRequestify(transactionRequestLike);
     const txRequestToSend =
       await this.populateTransactionWitnessesSignature(transactionRequest);

--- a/packages/app/src/systems/DApp/hooks/useTransactionRequest.tsx
+++ b/packages/app/src/systems/DApp/hooks/useTransactionRequest.tsx
@@ -58,6 +58,7 @@ const selectors = {
     if (state.matches('txSuccess')) return 'Transaction sent';
     if (state.matches('txFailed')) return 'Transaction failed';
     if (state.matches('sendingTx')) return 'Sending transaction';
+    if (state.context.input.signOnly) return 'Sign Transaction';
     return 'Review Transaction';
   },
   origin: (state: TransactionRequestState) => state.context.input.origin,

--- a/packages/app/src/systems/DApp/hooks/useTransactionRequest.tsx
+++ b/packages/app/src/systems/DApp/hooks/useTransactionRequest.tsx
@@ -55,10 +55,10 @@ const selectors = {
     return !isWaitingApproval || hasSimulateTxErrors;
   },
   title(state: TransactionRequestState) {
+    if (state.context.input.signOnly) return 'Sign Transaction';
     if (state.matches('txSuccess')) return 'Transaction sent';
     if (state.matches('txFailed')) return 'Transaction failed';
     if (state.matches('sendingTx')) return 'Sending transaction';
-    if (state.context.input.signOnly) return 'Sign Transaction';
     return 'Review Transaction';
   },
   origin: (state: TransactionRequestState) => state.context.input.origin,

--- a/packages/app/src/systems/DApp/machines/transactionRequestMachine.tsx
+++ b/packages/app/src/systems/DApp/machines/transactionRequestMachine.tsx
@@ -389,6 +389,21 @@ export const transactionRequestMachine = createMachine(
         }),
       }),
       assignSimulateTxErrors: assign((ctx, ev) => {
+        if (ev.data.simulateTxErrors) {
+          return {
+            ...ctx,
+            response: {
+              ...ctx.response,
+              txSummarySimulated: undefined,
+              proposedTxRequest: undefined,
+            },
+            errors: {
+              ...ctx.errors,
+              simulateTxErrors: ev.data.simulateTxErrors,
+            },
+          };
+        }
+
         return {
           ...ctx,
           errors: {

--- a/packages/app/src/systems/DApp/machines/transactionRequestMachine.tsx
+++ b/packages/app/src/systems/DApp/machines/transactionRequestMachine.tsx
@@ -391,17 +391,6 @@ export const transactionRequestMachine = createMachine(
           };
         },
       }),
-      assignApprovedTx: assign({
-        response: (ctx, ev) => {
-          const isTransactionResponse = 'provider' in ev.data;
-          return {
-            ...ctx.response,
-            ...(isTransactionResponse
-              ? { txResponse: ev.data as TransactionResponse }
-              : { txSummaryExecuted: ev.data as TransactionSummary }),
-          };
-        },
-      }),
       assignSimulateResult: assign({
         response: (ctx, ev) => ({
           ...ctx.response,
@@ -435,18 +424,6 @@ export const transactionRequestMachine = createMachine(
             ...ctx.errors,
             simulateTxErrors: ev.data.simulateTxErrors,
           },
-        };
-      }),
-      assignTxApproveError: assign((ctx, ev) => {
-        return {
-          ...ctx,
-          errors: {
-            ...ctx.errors,
-            // biome-ignore lint/suspicious/noExplicitAny: <explanation>
-            txApproveError: (ev.data as any)?.error,
-          },
-          // biome-ignore lint/suspicious/noExplicitAny: <explanation>
-          error: (ev.data as any)?.error,
         };
       }),
     },

--- a/packages/app/src/systems/DApp/methods.ts
+++ b/packages/app/src/systems/DApp/methods.ts
@@ -23,6 +23,7 @@ export class RequestMethods extends ExtensionPageConnection {
     this.addAssets,
     this.selectNetwork,
     this.addNetwork,
+    this.signTransaction,
   ];
   constructor() {
     super();
@@ -48,6 +49,17 @@ export class RequestMethods extends ExtensionPageConnection {
   }
 
   async sendTransaction(input: MessageInputs['sendTransaction']) {
+    console.log(
+      '[DApp/methods] sendTransaction (called by PopUpService) with input:',
+      {
+        address: input.address,
+        hasProvider: !!input.provider,
+        providerUrl: input.provider?.url,
+        noSendReturnPayload: input.noSendReturnPayload,
+        returnTransactionResponse: input.returnTransactionResponse,
+      }
+    );
+
     const {
       address,
       provider,
@@ -59,8 +71,11 @@ export class RequestMethods extends ExtensionPageConnection {
       transactionState,
       transactionSummary,
       returnTransactionResponse,
+      noSendReturnPayload,
     } = input;
     const transactionRequest = transactionRequestify(JSON.parse(transaction));
+
+    console.log('[DApp/methods] Parsed transaction request for machine');
 
     const state = await store
       .requestTransaction({
@@ -73,18 +88,46 @@ export class RequestMethods extends ExtensionPageConnection {
         skipCustomFee,
         transactionState,
         transactionSummary,
+        noSendReturnPayload: input.noSendReturnPayload,
       })
       .waitForState(Services.txRequest, {
         ...WAIT_FOR_CONFIG,
         done: 'txSuccess',
       });
 
+    console.log(
+      '[DApp/methods] Transaction machine has reached txSuccess. Context response:',
+      state.context.response
+    );
+    console.log('[DApp/methods] Machine state details:', {
+      hasSignedTransactionInContext:
+        !!state.context.response?.signedTransaction,
+      signatureLengthInContext:
+        state.context.response?.signedTransaction?.length,
+      actualSignedTransactionInContext:
+        state.context.response?.signedTransaction,
+      txResponseInContext: state.context.response?.txResponse,
+      noSendReturnPayloadFromInput: noSendReturnPayload,
+      returnTransactionResponseFromInput: returnTransactionResponse,
+    });
+
+    if (noSendReturnPayload) {
+      console.log(
+        '[DApp/methods] noSendReturnPayload is true. Returning signedTransaction from context:',
+        state.context.response?.signedTransaction
+      );
+      return state.context.response?.signedTransaction;
+    }
+
     const txId =
       state.context.response?.txResponse?.id ||
       state.context.response?.txSummaryExecuted?.id;
 
     if (!returnTransactionResponse) {
-      // it will be always txResponse, but just for safety we check both
+      console.log(
+        '[DApp/methods] returnTransactionResponse is false. Returning txId:',
+        txId
+      );
       return txId;
     }
 
@@ -93,12 +136,19 @@ export class RequestMethods extends ExtensionPageConnection {
         const serializedTxResponse = await serializeTransactionResponseJson(
           state.context.response.txResponse
         );
+        console.log(
+          '[DApp/methods] returnTransactionResponse is true. Returning serializedTxResponse.'
+        );
         return serializedTxResponse;
       } catch (error) {
-        console.error('Error serializing transaction response:', error);
+        console.error(
+          '[DApp/methods] Error serializing transaction response:',
+          error
+        );
       }
     }
 
+    console.log('[DApp/methods] Fallback. Returning txId:', txId);
     return txId;
   }
 
@@ -121,6 +171,42 @@ export class RequestMethods extends ExtensionPageConnection {
       .requestSelectNetwork(input)
       .waitForState(Services.selectNetworkRequest, WAIT_FOR_CONFIG);
     return true;
+  }
+
+  async signTransaction(input: MessageInputs['signTransaction']) {
+    console.log('[DApp/methods] signTransaction called with:', {
+      address: input.address,
+      hasProvider: !!input.provider,
+      providerUrl: input.provider?.url,
+    });
+
+    const { address, provider, transaction, origin, title, favIconUrl } = input;
+    const transactionRequest = transactionRequestify(JSON.parse(transaction));
+
+    console.log('[DApp/methods] Parsed transaction request');
+
+    const state = await store
+      .requestTransaction({
+        origin,
+        transactionRequest,
+        address,
+        providerConfig: provider,
+        title,
+        favIconUrl,
+        skipCustomFee: true,
+        noSendReturnPayload: true,
+      })
+      .waitForState(Services.txRequest, {
+        ...WAIT_FOR_CONFIG,
+        done: 'txSuccess',
+      });
+
+    console.log('[DApp/methods] Transaction machine state:', {
+      hasSignedTransaction: !!state.context.response?.signedTransaction,
+      signatureLength: state.context.response?.signedTransaction?.length,
+    });
+
+    return state.context.response?.signedTransaction;
   }
 }
 

--- a/packages/app/src/systems/DApp/methods.ts
+++ b/packages/app/src/systems/DApp/methods.ts
@@ -49,17 +49,6 @@ export class RequestMethods extends ExtensionPageConnection {
   }
 
   async sendTransaction(input: MessageInputs['sendTransaction']) {
-    console.log(
-      '[DApp/methods] sendTransaction (called by PopUpService) with input:',
-      {
-        address: input.address,
-        hasProvider: !!input.provider,
-        providerUrl: input.provider?.url,
-        noSendReturnPayload: input.noSendReturnPayload,
-        returnTransactionResponse: input.returnTransactionResponse,
-      }
-    );
-
     const {
       address,
       provider,
@@ -74,8 +63,6 @@ export class RequestMethods extends ExtensionPageConnection {
       noSendReturnPayload,
     } = input;
     const transactionRequest = transactionRequestify(JSON.parse(transaction));
-
-    console.log('[DApp/methods] Parsed transaction request for machine');
 
     const state = await store
       .requestTransaction({
@@ -95,27 +82,7 @@ export class RequestMethods extends ExtensionPageConnection {
         done: 'txSuccess',
       });
 
-    console.log(
-      '[DApp/methods] Transaction machine has reached txSuccess. Context response:',
-      state.context.response
-    );
-    console.log('[DApp/methods] Machine state details:', {
-      hasSignedTransactionInContext:
-        !!state.context.response?.signedTransaction,
-      signatureLengthInContext:
-        state.context.response?.signedTransaction?.length,
-      actualSignedTransactionInContext:
-        state.context.response?.signedTransaction,
-      txResponseInContext: state.context.response?.txResponse,
-      noSendReturnPayloadFromInput: noSendReturnPayload,
-      returnTransactionResponseFromInput: returnTransactionResponse,
-    });
-
     if (noSendReturnPayload) {
-      console.log(
-        '[DApp/methods] noSendReturnPayload is true. Returning signedTransaction from context:',
-        state.context.response?.signedTransaction
-      );
       return state.context.response?.signedTransaction;
     }
 
@@ -124,10 +91,6 @@ export class RequestMethods extends ExtensionPageConnection {
       state.context.response?.txSummaryExecuted?.id;
 
     if (!returnTransactionResponse) {
-      console.log(
-        '[DApp/methods] returnTransactionResponse is false. Returning txId:',
-        txId
-      );
       return txId;
     }
 
@@ -135,9 +98,6 @@ export class RequestMethods extends ExtensionPageConnection {
       try {
         const serializedTxResponse = await serializeTransactionResponseJson(
           state.context.response.txResponse
-        );
-        console.log(
-          '[DApp/methods] returnTransactionResponse is true. Returning serializedTxResponse.'
         );
         return serializedTxResponse;
       } catch (error) {
@@ -148,7 +108,6 @@ export class RequestMethods extends ExtensionPageConnection {
       }
     }
 
-    console.log('[DApp/methods] Fallback. Returning txId:', txId);
     return txId;
   }
 
@@ -174,16 +133,8 @@ export class RequestMethods extends ExtensionPageConnection {
   }
 
   async signTransaction(input: MessageInputs['signTransaction']) {
-    console.log('[DApp/methods] signTransaction called with:', {
-      address: input.address,
-      hasProvider: !!input.provider,
-      providerUrl: input.provider?.url,
-    });
-
     const { address, provider, transaction, origin, title, favIconUrl } = input;
     const transactionRequest = transactionRequestify(JSON.parse(transaction));
-
-    console.log('[DApp/methods] Parsed transaction request');
 
     const state = await store
       .requestTransaction({
@@ -200,11 +151,6 @@ export class RequestMethods extends ExtensionPageConnection {
         ...WAIT_FOR_CONFIG,
         done: 'txSuccess',
       });
-
-    console.log('[DApp/methods] Transaction machine state:', {
-      hasSignedTransaction: !!state.context.response?.signedTransaction,
-      signatureLength: state.context.response?.signedTransaction?.length,
-    });
 
     return state.context.response?.signedTransaction;
   }

--- a/packages/app/src/systems/DApp/methods.ts
+++ b/packages/app/src/systems/DApp/methods.ts
@@ -60,7 +60,7 @@ export class RequestMethods extends ExtensionPageConnection {
       transactionState,
       transactionSummary,
       returnTransactionResponse,
-      noSendReturnPayload,
+      signOnly,
     } = input;
     const transactionRequest = transactionRequestify(JSON.parse(transaction));
 
@@ -75,14 +75,14 @@ export class RequestMethods extends ExtensionPageConnection {
         skipCustomFee,
         transactionState,
         transactionSummary,
-        noSendReturnPayload: input.noSendReturnPayload,
+        signOnly: input.signOnly,
       })
       .waitForState(Services.txRequest, {
         ...WAIT_FOR_CONFIG,
         done: 'txSuccess',
       });
 
-    if (noSendReturnPayload) {
+    if (signOnly) {
       return state.context.response?.signedTransaction;
     }
 
@@ -145,7 +145,7 @@ export class RequestMethods extends ExtensionPageConnection {
         title,
         favIconUrl,
         skipCustomFee: true,
-        noSendReturnPayload: true,
+        signOnly: true,
       })
       .waitForState(Services.txRequest, {
         ...WAIT_FOR_CONFIG,

--- a/packages/app/src/systems/DApp/methods.ts
+++ b/packages/app/src/systems/DApp/methods.ts
@@ -60,7 +60,6 @@ export class RequestMethods extends ExtensionPageConnection {
       transactionState,
       transactionSummary,
       returnTransactionResponse,
-      signOnly,
     } = input;
     const transactionRequest = transactionRequestify(JSON.parse(transaction));
 
@@ -75,16 +74,11 @@ export class RequestMethods extends ExtensionPageConnection {
         skipCustomFee,
         transactionState,
         transactionSummary,
-        signOnly: input.signOnly,
       })
       .waitForState(Services.txRequest, {
         ...WAIT_FOR_CONFIG,
         done: 'txSuccess',
       });
-
-    if (signOnly) {
-      return state.context.response?.signedTransaction;
-    }
 
     const txId =
       state.context.response?.txResponse?.id ||
@@ -152,7 +146,13 @@ export class RequestMethods extends ExtensionPageConnection {
         done: 'txSuccess',
       });
 
-    return state.context.response?.signedTransaction;
+    const txRequestSigned = state.context.response?.txRequestSigned;
+
+    if (!txRequestSigned) {
+      throw new Error('Transaction request not signed');
+    }
+
+    return JSON.stringify(txRequestSigned.toJSON());
   }
 }
 

--- a/packages/app/src/systems/DApp/pages/TransactionRequest/TransactionRequest.tsx
+++ b/packages/app/src/systems/DApp/pages/TransactionRequest/TransactionRequest.tsx
@@ -1,5 +1,5 @@
 import { cssObj } from '@fuel-ui/css';
-import { Button } from '@fuel-ui/react';
+import { Box, Button } from '@fuel-ui/react';
 import { bn } from 'fuels';
 import { useMemo } from 'react';
 import { Layout, coreStyles } from '~/systems/Core';
@@ -35,6 +35,8 @@ export function TransactionRequest() {
     isSimulating,
     input,
   } = txRequest;
+  const isSignOnly = !!input.noSendReturnPayload;
+
   const defaultValues = useMemo<TransactionRequestFormData | undefined>(() => {
     if (!txSummarySimulated || !proposedTxRequest) return undefined;
 
@@ -74,6 +76,12 @@ export function TransactionRequest() {
         <Layout.TopBar hideMenu hideBackArrow />
         {shouldShowReviewAlert && <TxReviewAlert />}
         <Layout.Content css={styles.content} noScroll>
+          {isSignOnly && (
+            <Box css={{ mb: '$4', p: '$3', fontWeight: '$normal' }}>
+              You are signing this transaction without broadcasting it to the
+              network.
+            </Box>
+          )}
           {shouldShowTxSimulated && (
             <TxContent.Info
               showDetails
@@ -123,7 +131,7 @@ export function TransactionRequest() {
               isLoading={isLoading || status('sending') || isSimulating}
               isDisabled={shouldDisableApproveBtn}
             >
-              Submit
+              {isSignOnly ? 'Sign' : 'Submit'}
             </Button>
           </Layout.BottomBar>
         )}

--- a/packages/app/src/systems/DApp/pages/TransactionRequest/TransactionRequest.tsx
+++ b/packages/app/src/systems/DApp/pages/TransactionRequest/TransactionRequest.tsx
@@ -35,7 +35,7 @@ export function TransactionRequest() {
     isSimulating,
     input,
   } = txRequest;
-  const isSignOnly = !!input.noSendReturnPayload;
+  const isSignOnly = !!input.signOnly;
 
   const defaultValues = useMemo<TransactionRequestFormData | undefined>(() => {
     if (!txSummarySimulated || !proposedTxRequest) return undefined;
@@ -93,6 +93,7 @@ export function TransactionRequest() {
               isLoading={isLoading}
               txAccount={input?.address}
               isSimulating={isSimulating}
+              signOnly={isSignOnly}
             />
           )}
           {shouldShowTxExecuted && txSummaryExecuted && (

--- a/packages/app/src/systems/DApp/pages/TransactionRequest/TransactionRequest.tsx
+++ b/packages/app/src/systems/DApp/pages/TransactionRequest/TransactionRequest.tsx
@@ -74,14 +74,8 @@ export function TransactionRequest() {
 
       <Layout title={title} isLoading={isLoading}>
         <Layout.TopBar hideMenu hideBackArrow />
-        {shouldShowReviewAlert && <TxReviewAlert />}
+        {shouldShowReviewAlert && <TxReviewAlert signOnly={isSignOnly} />}
         <Layout.Content css={styles.content} noScroll>
-          {isSignOnly && (
-            <Box css={{ mb: '$4', p: '$3', fontWeight: '$normal' }}>
-              You are signing this transaction without broadcasting it to the
-              network.
-            </Box>
-          )}
           {shouldShowTxSimulated && (
             <TxContent.Info
               showDetails

--- a/packages/app/src/systems/Transaction/components/TxContent/TxContent.tsx
+++ b/packages/app/src/systems/Transaction/components/TxContent/TxContent.tsx
@@ -6,7 +6,6 @@ import {
   ContentLoader,
   Copyable,
   Icon,
-  Text,
 } from '@fuel-ui/react';
 import type {
   BN,
@@ -14,6 +13,7 @@ import type {
   TransactionStatus,
   TransactionSummary,
 } from 'fuels';
+import { bn } from 'fuels';
 import { type ReactNode, useMemo } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { useAccounts } from '~/systems/Account';
@@ -101,6 +101,7 @@ export type TxContentInfoProps = {
   txAccount?: string;
   isSimulating?: boolean;
   isPastTense?: boolean;
+  signOnly?: boolean;
 };
 
 function TxContentInfo({
@@ -116,6 +117,7 @@ function TxContentInfo({
   txAccount,
   isSimulating,
   isPastTense = false,
+  signOnly = false,
 }: TxContentInfoProps) {
   const { account: currentAccount } = useAccounts();
   const formContext = useFormContext<SendFormValues>();
@@ -188,13 +190,24 @@ function TxContentInfo({
                 fees?.baseFee &&
                 txRequestGasLimit &&
                 fees?.regularTip &&
-                fees?.fastTip && (
+                fees?.fastTip &&
+                !signOnly && (
                   <TxFeeOptions
                     initialAdvanced={initialAdvanced}
                     baseFee={fees.baseFee}
                     gasLimit={txRequestGasLimit}
                     regularTip={fees.regularTip}
                     fastTip={fees.fastTip}
+                  />
+                )}
+              {showDetails &&
+                fees?.baseFee &&
+                txRequestGasLimit &&
+                signOnly && (
+                  <TxFee
+                    fee={fees.baseFee.add(
+                      fees.regularTip || fees.fastTip || bn(0)
+                    )}
                   />
                 )}
             </TxFeeSection>

--- a/packages/app/src/systems/Transaction/components/TxReviewAlert/TxReviewAlert.tsx
+++ b/packages/app/src/systems/Transaction/components/TxReviewAlert/TxReviewAlert.tsx
@@ -1,7 +1,11 @@
 import { cssObj } from '@fuel-ui/css';
 import { Box, Icon } from '@fuel-ui/react';
 
-export const TxReviewAlert = () => {
+export type TxReviewAlertProps = {
+  signOnly?: boolean;
+};
+
+export const TxReviewAlert = ({ signOnly = false }: TxReviewAlertProps) => {
   return (
     <Box
       css={{ borderBottom: '1px solid $gray6' }}
@@ -9,7 +13,9 @@ export const TxReviewAlert = () => {
     >
       <Box.Flex css={styles.reviewTxBadge}>
         <Icon icon="InfoCircle" stroke={2} size={16} />
-        Double-check transaction details before submission
+        {signOnly
+          ? 'Double-check transaction details before signing'
+          : 'Double-check transaction details before submission'}
       </Box.Flex>
     </Box>
   );

--- a/packages/app/src/systems/Transaction/pages/TxApprove/TxApprove.tsx
+++ b/packages/app/src/systems/Transaction/pages/TxApprove/TxApprove.tsx
@@ -19,25 +19,6 @@ export const TxApprove = () => {
   const { handlers } = useTransactionRequest();
   const isSignOnly = !!ctx.input.noSendReturnPayload;
 
-  // Log simulation errors if present
-  if (ctx.errors?.simulateTxErrors) {
-    // eslint-disable-next-line no-console
-    console.log(
-      '[TxApprove] Simulation Errors:',
-      JSON.stringify(ctx.errors.simulateTxErrors)
-    );
-  }
-  // Log shouldDisableApproveBtn state
-  // eslint-disable-next-line no-console
-  console.log(
-    '[TxApprove] shouldDisableApproveBtn:',
-    ctx.shouldDisableApproveBtn,
-    'isWaitingApproval:',
-    ctx.status('waitingApproval'),
-    'hasSimulateTxErrors:',
-    !!ctx.errors?.simulateTxErrors
-  );
-
   const handleReject = () => {
     handlers.closeDialog();
     handlers.reset();

--- a/packages/app/src/systems/Transaction/pages/TxApprove/TxApprove.tsx
+++ b/packages/app/src/systems/Transaction/pages/TxApprove/TxApprove.tsx
@@ -17,6 +17,26 @@ export const TxApprove = () => {
   const shouldShowReviewAlert =
     !ctx.status(TxRequestStatus.success) && !ctx.status(TxRequestStatus.failed);
   const { handlers } = useTransactionRequest();
+  const isSignOnly = !!ctx.input.noSendReturnPayload;
+
+  // Log simulation errors if present
+  if (ctx.errors?.simulateTxErrors) {
+    // eslint-disable-next-line no-console
+    console.log(
+      '[TxApprove] Simulation Errors:',
+      JSON.stringify(ctx.errors.simulateTxErrors)
+    );
+  }
+  // Log shouldDisableApproveBtn state
+  // eslint-disable-next-line no-console
+  console.log(
+    '[TxApprove] shouldDisableApproveBtn:',
+    ctx.shouldDisableApproveBtn,
+    'isWaitingApproval:',
+    ctx.status('waitingApproval'),
+    'hasSimulateTxErrors:',
+    !!ctx.errors?.simulateTxErrors
+  );
 
   const handleReject = () => {
     handlers.closeDialog();
@@ -32,6 +52,12 @@ export const TxApprove = () => {
       <Layout.TopBar hideMenu onBack={handleReject} />
       {shouldShowReviewAlert && <TxReviewAlert />}
       <Dialog.Description as="div" css={styles.description}>
+        {isSignOnly && (
+          <Box css={{ mb: '$4', fontWeight: '$normal' }}>
+            You are signing this transaction without broadcasting it to the
+            network.
+          </Box>
+        )}
         {ctx.shouldShowTxSimulated && ctx.txSummarySimulated && (
           <TxContent.Info
             showDetails
@@ -90,7 +116,7 @@ export const TxApprove = () => {
             onPress={ctx.handlers.approve}
             css={styles.footerButton}
           >
-            Submit
+            {isSignOnly ? 'Sign' : 'Submit'}
           </Button>
         </Dialog.Footer>
       )}

--- a/packages/app/src/systems/Transaction/pages/TxApprove/TxApprove.tsx
+++ b/packages/app/src/systems/Transaction/pages/TxApprove/TxApprove.tsx
@@ -17,7 +17,7 @@ export const TxApprove = () => {
   const shouldShowReviewAlert =
     !ctx.status(TxRequestStatus.success) && !ctx.status(TxRequestStatus.failed);
   const { handlers } = useTransactionRequest();
-  const isSignOnly = !!ctx.input.noSendReturnPayload;
+  const isSignOnly = !!ctx.input.signOnly;
 
   const handleReject = () => {
     handlers.closeDialog();
@@ -45,6 +45,7 @@ export const TxApprove = () => {
             tx={ctx.txSummarySimulated}
             errors={ctx.errors.simulateTxErrors}
             isSimulating={ctx.isSimulating}
+            signOnly={isSignOnly}
             footer={
               ctx.status('failed') && (
                 <Button

--- a/packages/app/src/systems/Transaction/pages/TxApprove/TxApprove.tsx
+++ b/packages/app/src/systems/Transaction/pages/TxApprove/TxApprove.tsx
@@ -31,7 +31,7 @@ export const TxApprove = () => {
   return (
     <Box css={styles.wrapper}>
       <Layout.TopBar hideMenu onBack={handleReject} />
-      {shouldShowReviewAlert && <TxReviewAlert />}
+      {shouldShowReviewAlert && <TxReviewAlert signOnly={isSignOnly} />}
       <Dialog.Description as="div" css={styles.description}>
         {isSignOnly && (
           <Box css={{ mb: '$4', fontWeight: '$normal' }}>

--- a/packages/app/src/systems/Transaction/services/transaction.tsx
+++ b/packages/app/src/systems/Transaction/services/transaction.tsx
@@ -191,8 +191,10 @@ export class TxService {
       provider
     );
 
-    const signature = await wallet.signTransaction(transactionRequest);
-    return { signedTransaction: signature };
+    const txRequest =
+      await wallet.populateTransactionWitnessesSignature(transactionRequest);
+
+    return txRequest;
   }
 
   static async send({

--- a/packages/app/src/systems/Transaction/services/transaction.tsx
+++ b/packages/app/src/systems/Transaction/services/transaction.tsx
@@ -185,41 +185,21 @@ export class TxService {
     providerConfig,
     noSendReturnPayload,
   }: TxInputs['send']) {
-    console.log('[TxService] send called with:', {
-      hasAccount: !!account,
-      address: address?.toString(),
-      hasTransaction: !!transactionRequest,
-      providerUrl,
-      configUrl: providerConfig?.url,
-      noSendReturnPayload,
-    });
-
     const provider = await createProvider(
       providerUrl || providerConfig?.url || ''
     );
-    console.log('[TxService] Created provider with URL:', provider.url);
-
     const wallet = new WalletLockedCustom(
       (account?.address?.toString() || address) as string,
       provider
     );
-    console.log(
-      '[TxService] Created wallet with address:',
-      wallet.address.toString()
-    );
 
     if (noSendReturnPayload) {
-      console.log('[TxService] Signing transaction without broadcasting');
       const signature = await wallet.signTransaction(transactionRequest);
-      console.log(
-        `[TxService] Got signature: ${signature.substring(0, 20)}...`
-      );
+
       return { signedTransaction: signature };
     }
 
-    console.log('[TxService] Sending transaction (will broadcast)');
     const txSent = await wallet.sendTransaction(transactionRequest);
-    console.log('[TxService] Transaction sent, id:', txSent.id);
     return txSent;
   }
 


### PR DESCRIPTION
Related: https://github.com/FuelLabs/fuel-connectors/pull/523

- Closes FE-1653

# Summary
This PR introduces a new `signTransaction` method to the wallet's background service and DApp communication layer. This allows dApps to request a transaction signature without the wallet immediately broadcasting it.

**Key Changes:**

*   **`BackgroundService.ts`**:
    *   Added a `signTransaction` method that leverages the existing `sendTransaction` popup UI flow.
    *   It passes a `noSendReturnPayload: true` flag to `PopUpService.sendTransaction`.
*   **`PopUpService.ts`**:
    *   The `sendTransaction` method now (implicitly via DApp methods) handles the `noSendReturnPayload` flag. 
*   **`DApp/methods.ts`**:
    *   The `sendTransaction` method (handling requests from the popup) now checks for `noSendReturnPayload`.
    *   If `noSendReturnPayload` is true, it returns the `signedTransaction` string from the transaction machine's context.
    *   Otherwise, it proceeds with the existing logic to return the transaction ID or serialized response.
*   **`transactionRequestMachine.tsx`**:
    *   Updated `MachineContext` to include `noSendReturnPayload` in input and `signedTransaction` in the response.
    *   The `send` service in the machine now calls `TxService.send` which can return either a `TransactionResponse` or an object `{ signedTransaction: string }`.
    *   The `sendingTx` state's `onDone` handler has been updated to correctly process this new return type, storing either `txResponse` or `signedTransaction` in the context.
    *   Service type definitions (`MachineServices`) updated to reflect the new return type of the `send` service.
*   **`Transaction/services/transaction.tsx` (`TxService.send`)**:
    *   Modified to check for the `noSendReturnPayload` flag.
    *   If true, it calls `wallet.signTransaction(transactionRequest)` and returns `{ signedTransaction: signature }`.
    *   Otherwise, it calls `wallet.sendTransaction(transactionRequest)` and returns the `TransactionResponse`.
*   **UI (`TxApprove.tsx`, `TransactionRequest.tsx`)**:
    *   Updated to display "Sign" instead of "Submit" on the approval button when `noSendReturnPayload` is true.
    *   Added a message to inform the user that the transaction will only be signed and not broadcast.

**Impact:**

Enables new dApp functionalities requiring off-chain signing, such as multisig coordination or transaction relaying, by allowing dApps to receive a signed transaction payload.

# Checklist

- [ ] I've added error handling for all actions/requests, and verified how this error will show on UI. (or there was no error handling)
- [ ] I've reviewed all the copy changed/added in this PR, using AI if needed. (or there was no copy changes)
- [ ] I've included the reference to the issues being closed from Github and/or Linear (or there was no issues)
- [ ] I've changed the Docs to reflect my changes (or it was not needed)
- [ ] I've put docs links where it may be helpful (or it was not needed)
- [ ] I checked the resulting UI both in Light and Dark mode (or no UI changes were made)
- [ ] I **reviewed** the **entire PR** myself (preferably, on GH UI)
