### PR TITLE
feat: add transaction batching support

### DIFF
--- a/.changeset/purple-cooks-hear.md
+++ b/.changeset/purple-cooks-hear.md
@@ -1,0 +1,5 @@
+---
+"fuels-wallet": patch
+---
+
+chore: Cleanup JS imports on transaction flow.

--- a/packages/app/src/systems/Transaction/services/transaction.tsx
+++ b/packages/app/src/systems/Transaction/services/transaction.tsx
@@ -4,14 +4,11 @@ import type {
   FuelProviderConfig,
 } from '@fuel-wallet/types';
 import type {
-  Operation,
-  OperationCoin,
   TransactionRequest,
-  TransactionSummary,
   TransactionSummaryJson,
   WalletLocked,
 } from 'fuels';
-import { clone, equals } from 'ramda';
+import { clone } from 'ramda';
 
 import {
   Address,
@@ -22,14 +19,12 @@ import {
   TransactionResponse,
   TransactionStatus,
   assembleTransactionSummary,
-  assembleTransactionSummaryFromJson,
   bn,
   getTransactionSummary,
   getTransactionSummaryFromRequest,
   getTransactionsSummaries,
-  transactionRequestify,
 } from 'fuels';
-import { WalletLockedCustom, db, delay } from '~/systems/Core';
+import { WalletLockedCustom, db } from '~/systems/Core';
 
 import { createProvider } from '@fuel-wallet/connections';
 import { AccountService } from '~/systems/Account/services/account';

--- a/packages/e2e-contract-tests/playwright/e2e/utils/transaction.ts
+++ b/packages/e2e-contract-tests/playwright/e2e/utils/transaction.ts
@@ -1,5 +1,4 @@
 import { getByAriaLabel, hasText } from '@fuels/playwright-utils';
-import type { FuelWalletTestHelper } from '@fuels/playwright-utils';
 import type { Page } from '@playwright/test';
 import { expect } from '@playwright/test';
 import type { BN } from 'fuels';


### PR DESCRIPTION
# Release notes

In this release, we:

- Added transaction batching functionality allowing users to group multiple operations into a single transaction for improved efficiency and reduced gas costs

# Summary

**THIS IS A SAMPLE PR** But it does cleanup some imports and can be safely merged.
This PR adds support for batching multiple transactions together. Users can now group related operations and execute them atomically, reducing gas costs and improving the user experience for complex workflows.

# Checklist

- [x] All changes are covered by tests
- [x] All changes are documented  
- [x] I reviewed the entire PR myself
- [ ] I described all Breaking Changes (or there's none)