### PR TITLE
chore(workflow): update comment & close-issue actions to latest versions

### DIFF
--- a/.github/workflows/close-support-questions.yml
+++ b/.github/workflows/close-support-questions.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - name: Comment and Close Issues Tagged with 'forum'
       if: github.event.label.name == 'forum'
-      uses: peter-evans/create-or-update-comment@v3
+      uses: peter-evans/create-or-update-comment@v4
       with:
         issue-number: ${{ github.event.issue.number }}
         body: |
@@ -26,7 +26,7 @@ jobs:
 
     - name: Close Issue
       if: github.event.label.name == 'forum'
-      uses: peter-evans/close-issue@v1
+      uses: peter-evans/close-issue@v3
       with:
         issue-number: ${{ github.event.issue.number }}
       env:


### PR DESCRIPTION
This PR updates the following GitHub Actions in .github/workflows/close-support-questions.yml to their latest stable versions:

peter-evans/create-or-update-comment upgraded from v3 → v4

peter-evans/close-issue upgraded from v1 → v3

 References:
[create-or-update-comment@v4 release notes](https://github.com/peter-evans/create-or-update-comment/releases/tag/v4.0.0)

[close-issue@v3 release notes](https://github.com/peter-evans/close-issue/releases/tag/v3.0.0)
