### PR TITLE
Nj/feat/private key warning

### DIFF
--- a/.changeset/famous-donuts-sniff.md
+++ b/.changeset/famous-donuts-sniff.md
@@ -1,0 +1,5 @@
+---
+"fuels-wallet": patch
+---
+
+feat: Add warning for exporting seed phrase of imported private keys

--- a/packages/app/src/systems/Settings/hooks/useExportVault.tsx
+++ b/packages/app/src/systems/Settings/hooks/useExportVault.tsx
@@ -12,7 +12,7 @@ const selectors = {
   error: (state: ExportVaultMachineState) => state.context.error,
 };
 
-export function useExportVault() {
+export function useExportVault(vaultId?: number) {
   const service = useInterpret(() => exportVaultMachine);
   const isLoading = useSelector(service, selectors.isLoading);
   const error = useSelector(service, selectors.error);
@@ -23,16 +23,24 @@ export function useExportVault() {
     if (await VaultService.isLocked()) {
       await VaultService.unlock({ password });
     }
-    const [vault] = await VaultService.getVaults();
 
-    vault &&
+    let targetVaultId = vaultId;
+
+    // If no specific vaultId provided, use the first vault (main wallet behavior)
+    if (targetVaultId === undefined) {
+      const [vault] = await VaultService.getVaults();
+      targetVaultId = vault?.vaultId;
+    }
+
+    if (targetVaultId !== undefined) {
       service.send({
         type: 'EXPORT_VAULT',
         input: {
           password,
-          vaultId: vault.vaultId,
+          vaultId: targetVaultId,
         },
       });
+    }
   }
 
   return {

--- a/packages/app/src/systems/Settings/pages/ViewSeedPhrase/ViewSeedPhrase.tsx
+++ b/packages/app/src/systems/Settings/pages/ViewSeedPhrase/ViewSeedPhrase.tsx
@@ -1,5 +1,6 @@
 import { cssObj } from '@fuel-ui/css';
-import { Alert, Box, Dialog } from '@fuel-ui/react';
+import { Alert, Box, Dialog, Text } from '@fuel-ui/react';
+import { useCurrentAccount } from '~/systems/Account/hooks/useCurrentAccount';
 import { Mnemonic, styles as coreStyles } from '~/systems/Core';
 import { OverlayDialogTopbar, useOverlay } from '~/systems/Overlay';
 import { UnlockCard } from '~/systems/Unlock';
@@ -8,8 +9,10 @@ import { useExportVault } from '../../hooks';
 
 export function ViewSeedPhrase() {
   const { close } = useOverlay();
-  const { handlers, error, isUnlockOpened, isLoading, words } =
-    useExportVault();
+  const { account } = useCurrentAccount();
+  const { handlers, error, isUnlockOpened, isLoading, words } = useExportVault(
+    account?.vaultId
+  );
 
   if (isUnlockOpened) {
     return (
@@ -25,23 +28,54 @@ export function ViewSeedPhrase() {
     );
   }
 
+  // Check if the account was imported via private key (no seed phrase available)
+  const isPrivateKeyAccount =
+    words.length === 0 || words.every((word) => !word);
+
   return (
     <>
       <OverlayDialogTopbar onClose={close}>Seed Phrase</OverlayDialogTopbar>
       <Dialog.Description as="div" css={coreStyles.content}>
         <Box.Flex gap="$4" direction="column" align="center">
-          <Box css={styles.mnemonicWrapper}>
-            <Mnemonic type="read" value={words} />
-          </Box>
-          <Alert status="warning">
-            <Alert.Description as="div">
-              <Box css={styles.alertFirstLine}>
-                NEVER SHARE your Recovery Phrase. {'\n'}
-                It provides full access to all your accounts.
+          {isPrivateKeyAccount ? (
+            <Box.Stack gap="$4" align="center">
+              <Alert status="info" css={styles.noSeedPhraseAlert}>
+                <Alert.Description as="div">
+                  <Text css={styles.noSeedPhraseTitle}>
+                    No Seed Phrase Available
+                  </Text>
+                  <Text>
+                    This account was imported using a private key and does not
+                    have a seed phrase. Private key imported accounts are not
+                    recoverable via a seed phrase.
+                  </Text>
+                </Alert.Description>
+              </Alert>
+              <Alert status="warning">
+                <Alert.Description>
+                  To backup this account, you need to export the private key
+                  instead. You can do this from the account menu by selecting
+                  "Export Private Key".
+                </Alert.Description>
+              </Alert>
+            </Box.Stack>
+          ) : (
+            <>
+              <Box css={styles.mnemonicWrapper}>
+                <Mnemonic type="read" value={words} />
               </Box>
-              Sharing or losing it may result in permanent loss of your funds.
-            </Alert.Description>
-          </Alert>
+              <Alert status="warning">
+                <Alert.Description as="div">
+                  <Box css={styles.alertFirstLine}>
+                    NEVER SHARE your Recovery Phrase. {'\n'}
+                    It provides full access to all your accounts.
+                  </Box>
+                  Sharing or losing it may result in permanent loss of your
+                  funds.
+                </Alert.Description>
+              </Alert>
+            </>
+          )}
         </Box.Flex>
       </Dialog.Description>
     </>
@@ -54,5 +88,11 @@ const styles = {
   }),
   alertFirstLine: cssObj({
     mb: '$2',
+  }),
+  noSeedPhraseAlert: cssObj({}),
+  noSeedPhraseTitle: cssObj({
+    fontWeight: '$semibold',
+    mb: '$2',
+    display: 'block',
   }),
 };


### PR DESCRIPTION
- Closes FE-1320

# Summary
<img width="352" alt="image" src="https://github.com/user-attachments/assets/7947fabd-c019-4365-bda1-f13204bb47f4" />

Added a warning for when the user has a Private Key imported account and tries to export the seed phrase.

# Checklist

- [x] I've added error handling for all actions/requests, and verified how this error will show on UI. (or there was no error handling)
- [x] I've reviewed all the copy changed/added in this PR, using AI if needed. (or there was no copy changes)
- [x] I checked the resulting UI both in Light and Dark mode (or no UI changes were made)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
