### PR TITLE
Refactor message signing to use HashableMessage type

### DIFF
--- a/packages/app/src/systems/DApp/machines/messageRequestMachine.tsx
+++ b/packages/app/src/systems/DApp/machines/messageRequestMachine.tsx
@@ -1,6 +1,6 @@
 import type { Account } from '@fuel-wallet/types';
 import type { HashableMessage } from 'fuels';
-import { arrayify, hashMessage } from 'fuels';
+import { arrayify } from 'fuels';
 import type { InterpreterFrom, StateFrom } from 'xstate';
 import { assign, createMachine } from 'xstate';
 import { AccountService } from '~/systems/Account';
@@ -150,9 +150,9 @@ export const messageRequestMachine = createMachine(
             throw new Error('Invalid network input');
           }
 
-          let messageString: string;
+          let message: HashableMessage;
           if (typeof input.message === 'string') {
-            messageString = input.message;
+            message = input.message;
           } else if (
             typeof input.message === 'object' &&
             input.message.personalSign
@@ -164,17 +164,17 @@ export const messageRequestMachine = createMachine(
               const uint8Array = new Uint8Array(
                 Object.values(input.message.personalSign)
               );
-              messageString = hashMessage({ personalSign: uint8Array });
+              message = { personalSign: uint8Array };
             } else {
               const uint8Array = arrayify(input.message.personalSign);
-              messageString = hashMessage({ personalSign: uint8Array });
+              message = { personalSign: uint8Array };
             }
           } else {
-            messageString = hashMessage(input.message);
+            message = input.message;
           }
 
           return VaultService.signMessage({
-            message: messageString,
+            message,
             address: input.address,
           });
         },

--- a/packages/app/src/systems/Vault/services/VaultServer.ts
+++ b/packages/app/src/systems/Vault/services/VaultServer.ts
@@ -1,7 +1,12 @@
 // biome-ignore lint/style/useNodejsImportProtocol: <explanation>
 import EventEmitter from 'events';
 import { createProvider } from '@fuel-wallet/connections';
-import { Address, WalletManager, transactionRequestify } from 'fuels';
+import {
+  Address,
+  type HashableMessage,
+  WalletManager,
+  transactionRequestify,
+} from 'fuels';
 import { JSONRPCServer } from 'json-rpc-2.0';
 import { IndexedDBStorage } from '~/systems/Account/utils/storage';
 
@@ -28,7 +33,7 @@ export type VaultInputs = {
     providerUrl: string;
   };
   signMessage: {
-    message: string;
+    message: HashableMessage;
     address: string;
   };
   changePassword: {


### PR DESCRIPTION
<!--
List the issues this PR closes (if any) in a bullet list format, e.g.:
- Fixes signature verification failures with Signer.recoverAddress
- Resolves double hashing of messages in wallet signing flow
-->

# Release notes

In this release, we:

- Fixed message signing to prevent double hashing, ensuring proper signature verification with `Signer.recoverAddress`
- Updated message handling to use `HashableMessage` type for better type safety

# Summary

This PR fixes a critical issue where messages were being hashed twice during the signing process:

1. **messageRequestMachine.tsx** was pre-hashing messages with `hashMessage()` before passing to VaultService
2. **WalletLockedCustom** was hashing the already-hashed message again during signing

This double hashing caused signature verification to fail when dApps used `Signer.recoverAddress()` with the original message hash.

# Checklist

- [x] I've added error handling for all actions/requests, and verified how this error will show on UI. (or there was no error handling)
- [x] I've reviewed all the copy changed/added in this PR, using AI if needed. (or there was no copy changes)
- [x] I checked the resulting UI both in Light and Dark mode (or no UI changes were made)
- [x] I **reviewed** the **entire PR** myself (preferably, on