### PR TITLE
Fix typos in documentation and improve code comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Integrate your **DApp** using the [Wallet SDK](https://wallet.fuel.network/docs/
   - [🔗 - Request connection](https://wallet.fuel.network/docs/dev/connecting/)
   - [📒 - List user accounts](https://wallet.fuel.network/docs/dev/accounts/)
   - [✍️ - Signing a message](https://wallet.fuel.network/docs/dev/signMessage/)
-  - [✍️ - Transfering assets](https://wallet.fuel.network/docs/dev/assets/)
+  - [✍️ - Transferring assets](https://wallet.fuel.network/docs/dev/assets/)
   - [📗 SDK API](https://wallet.fuel.network/docs/dev/reference/)
 - [Contributing](https://wallet.fuel.network/docs/contributing/guide/)
   - [Contribution Guide](https://wallet.fuel.network/docs/contributing/guide/)

--- a/packages/app/src/systems/SignUp/machines/signUpMachine.ts
+++ b/packages/app/src/systems/SignUp/machines/signUpMachine.ts
@@ -79,7 +79,7 @@ export const signUpMachine = createMachine(
         on: {
           CREATE: {
             actions: ['assignCreate'],
-            target: 'aggrement',
+            target: 'agreement',
           },
           IMPORT: {
             actions: ['assignImport'],
@@ -218,7 +218,7 @@ export const signUpMachine = createMachine(
           mnemonic: getWordsFromValue(ev.data.words),
         }),
       }),
-      // Passowrd
+      // Password
       assignPassword: assign({
         data: (ctx, ev) => ({
           ...ctx.data,


### PR DESCRIPTION


---


**Description:**  
- Corrected a typo in the README link ("Transfering" → "Transferring").
- Fixed a typo in the state machine target ("aggrement" → "agreement").
- Improved code readability by updating the password section comment.
  

---