### PR TITLE
feat: Add MaintenanceBanner component to Layout

### DIFF
--- a/packages/app/src/systems/Core/components/Layout/Layout.tsx
+++ b/packages/app/src/systems/Core/components/Layout/Layout.tsx
@@ -12,6 +12,7 @@ import { Sidebar } from '~/systems/Sidebar';
 import { coreStyles } from '../../styles/core';
 
 import { BottomBar } from './BottomBar';
+import { MaintenanceBanner } from './MaintenanceBanner';
 import { TopBar } from './TopBar';
 
 type Context = {
@@ -97,6 +98,7 @@ export const Layout: LayoutComponent = ({
               className="layout__wrapper"
               data-noborder={noBorder}
             >
+              <MaintenanceBanner />
               <OverlayDialog />
               <Sidebar ref={ref} />
               <Box ref={ref} css={styles.inner} className="layout__inner">

--- a/packages/app/src/systems/Core/components/Layout/MaintenanceBanner.tsx
+++ b/packages/app/src/systems/Core/components/Layout/MaintenanceBanner.tsx
@@ -1,0 +1,43 @@
+import { cssObj } from '@fuel-ui/css';
+import { Alert, Box, Icon } from '@fuel-ui/react';
+
+export function MaintenanceBanner() {
+  return (
+    <Alert status="warning" css={styles.root} direction="row">
+      <Alert.Description css={styles.description}>
+        <Box css={styles.content}>
+          <Icon icon="AlertTriangle" size={16} />
+          The network is undergoing a scheduled migration today starting 17:30
+          UTC. We expect to be back up shortly.
+        </Box>
+      </Alert.Description>
+    </Alert>
+  );
+}
+
+const styles = {
+  root: cssObj({
+    borderRadius: '0',
+    py: '$1',
+    px: '$1',
+    background: '$intentsWarning3',
+    '&:after': {
+      display: 'none',
+    },
+    '.fuel_Alert-icon': {
+      display: 'none',
+    },
+  }),
+  description: cssObj({
+    width: '100%',
+    textAlign: 'center',
+    fontSize: '$xs',
+    color: '$intentsWarning11',
+  }),
+  content: cssObj({
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: '$2',
+  }),
+};


### PR DESCRIPTION
Introduce a new MaintenanceBanner component and render it in the main Layout. The banner displays a warning about a scheduled network migration (starts 17:30 UTC) and is styled to span the layout width with centered text and warning colors. The change adds a new file packages/app/src/systems/Core/components/Layout/MaintenanceBanner.tsx and imports/places <MaintenanceBanner /> near the top of the layout wrapper so users see the notice immediately.

<!--
List the issues this PR closes (if any) in a bullet list format, e.g.:
- Closes #ABCD
- Closes #EFGH
-->

# Release notes

<!--
Use this only if this PR requires a mention in the Release
Notes Summary. Valuable features and critical fixes are good
examples. For everything else, please delete the whole section.
-->

In this release, we:

- Did this and that <!-- edit this text only -->

# Summary

<!--
Please write a summary of your changes and why you made them.
Not all PRs will be complex or substantial enough to require this
section, so you can remove it if you think it's unnecessary.
-->

# Breaking Changes

<!--
If the PR has breaking changes, please detail them in this section
and remove this comment.

Remove this section if there are no breaking changes.
-->

# Checklist

- [ ] I've added error handling for all actions/requests, and verified how this error will show on UI. (or there was no error handling)
- [ ] I've reviewed all the copy changed/added in this PR, using AI if needed. (or there was no copy changes)
- [ ] I checked the resulting UI both in Light and Dark mode (or no UI changes were made)
- [ ] I **reviewed** the **entire PR** myself (preferably, on GH UI)
